### PR TITLE
Preserve lazy nature of Nc4DatasetLike variable data

### DIFF
--- a/lib/ncdata/dataset_like.py
+++ b/lib/ncdata/dataset_like.py
@@ -282,7 +282,7 @@ class Nc4VariableLike(_Nc4DatalikeWithNcattrs):
         # N.B. fill-value matches the internal raw (unscaled) values and dtype
         fv = self._get_fillvalue()
         if fv is not None:
-            array = np.ma.masked_equal(array, fv)
+            array = da.ma.masked_equal(array, fv)
 
         is_scaled, scale_factor, add_offset = self._get_scaling()
         if is_scaled:

--- a/tests/integration/example_scripts/ex_iris_xarray_conversion.py
+++ b/tests/integration/example_scripts/ex_iris_xarray_conversion.py
@@ -4,7 +4,7 @@ A proof-of-concept example workflow for :mod:`ncdata.iris_xarray`.
 Showing conversion from Xarray to Iris, and back again.
 """
 import iris
-import iris.tests as itsts
+import dask.array as da
 import numpy as np
 import xarray as xr
 
@@ -27,12 +27,15 @@ def example_from_xr():  # noqa: D103
     print("\nCube:")
     print(cube)
 
+    is_lazy = cube.has_lazy_data()
+    print("\nCube data still lazy ?", is_lazy)
+    # It really ought to be!
+    assert is_lazy
+
     data = cube.core_data()
     print("\ncube.core_data():")
     print(data)
-    # match = data is xrds['data'].data
-    # print('\ncube.core_data() is xrds["data"].data:')
-    # print(match)
+
     co_auxlons = cube.coord("longitude")
     print('\ncube.coord("longitude"):')
     print(co_auxlons)
@@ -46,6 +49,11 @@ def example_from_xr():  # noqa: D103
     xrds2 = cubes_to_xarray(cubes)
     print("\nxrds2:\n", xrds2)
     print("\ntime:\n", xrds2["time"])
+
+    is_lazy = isinstance(xrds2["data"].data, da.Array)
+    print("\nMain data variable still lazy ?", is_lazy)
+    # It really ought to be!
+    assert is_lazy
 
     print("\n")
     print("============ Array identity checks ... =========")


### PR DESCRIPTION
Also confirm in example code.
This was basically a bug introduced in #32 -- because `np.ma.masked_equal` does not vector to `da.ma.masked_equal`.

## TODO: 
  - [ ] ~add a proper unit test to ensure this works lazy-preserving~
  - **UPDATE** will do this within forthcoming extra tests for `ncdata.iris`
