### PR TITLE
decorator returns the wrapped function

### DIFF
--- a/tests/data_testcase_schemas.py
+++ b/tests/data_testcase_schemas.py
@@ -307,6 +307,7 @@ def standard_testcases_func(func):
     """
     global _Standard_Testcases
     _Standard_Testcases.update(func())
+    return func
 
 
 @standard_testcases_func


### PR DESCRIPTION
A decorator really "ought" to return a replacement for the original function. 
Found this when trying to import a testcase function for use elsewhere