### PR TITLE
Skip bad files in iris test-data

### DIFF
--- a/tests/integration/test_iris_xarray_roundtrips.py
+++ b/tests/integration/test_iris_xarray_roundtrips.py
@@ -78,6 +78,9 @@ def test_roundtrip_ixi(standard_testcase, use_irislock, adjust_chunks):
             "testdata____ugrid__21_triangle_example",
             # Problem with units on time bounds
             "label_and_climate__small_FC_167",
+            # Broken UGRID files now won't load in Iris >= 3.10
+            "unstructured_grid__mesh_C12",
+            "_unstructured_grid__theta_nodal_xios",
         ]
     )
     if any(key in standard_testcase.name for key in exclude_case_keys):


### PR DESCRIPTION
Since Iris 3.10,  Iris can no longer load UGRID files without interpretation.
But some files in the iris-test-data are bad, and cause load errors.

Ultimately, it might be nicer to either fix these files in the test data, or adopt [more tolerant Iris loading](https://github.com/SciTools/iris/issues/5165).
But for now here, we just need to avoid the errors.