### PR TITLE
Enforce that NcAttribute.value is always an 0- or 1-D array.

### DIFF
--- a/lib/ncdata/_core.py
+++ b/lib/ncdata/_core.py
@@ -503,11 +503,22 @@ class NcAttribute:
         #: attribute name
         self.name: str = name
         # Attribute values are arraylike, have dtype
-        # TODO: may need to regularise string representations?
-        if not hasattr(value, "dtype"):
-            value = np.asanyarray(value)
         #: attribute value
         self.value: np.ndarray = value
+
+    @property
+    def value(self):  # noqa: D102
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        if not hasattr(value, "dtype"):
+            value = np.asanyarray(value)
+        if value.ndim > 1:
+            raise ValueError(
+                "Attribute value should only be 0- or 1-dimensional."
+            )
+        self._value = value
 
     def as_python_value(self):
         """

--- a/lib/ncdata/utils/_compare_nc_datasets.py
+++ b/lib/ncdata/utils/_compare_nc_datasets.py
@@ -385,7 +385,7 @@ def variable_differences(
             isnans, isnans2 = (np.isnan(arr) for arr in (flatdata, flatdata2))
             if np.any(isnans) or np.any(isnans2):
                 nandiffs = np.where(isnans != isnans2)[0]
-                if nandiffs:
+                if nandiffs.size > 0:
                     flat_diff_inds += list(nandiffs)
                 anynans = isnans | isnans2
                 flatdata[anynans] = safe_fill_const


### PR DESCRIPTION
Closes #103

This aligns with statements rashly made in advance, in #105  !

But we may still want to take out some remaining warnings there, about "attribute.value" not always being what you expected/wanted.  
At least _setting_ it is now "safe" :  remove the "Why Not Just… set NcAttribute.value directly ?" section in the howtos