### PR TITLE
Equality tests for Dims and Attrs

### DIFF
--- a/lib/ncdata/_core.py
+++ b/lib/ncdata/_core.py
@@ -374,6 +374,14 @@ class NcDimension:
         """Copy self."""
         return NcDimension(self.name, size=self.size, unlimited=self.unlimited)
 
+    def __eq__(self, other):
+        """Support simply equality testing."""
+        return (
+            self.name == other.name
+            and self.size == other.size
+            and self.unlimited == other.unlimited
+        )
+
 
 class NcVariable(_AttributeAccessMixin):
     """
@@ -581,4 +589,20 @@ class NcAttribute:
         Does not duplicate array content.
         See :func:`ncdata.utils.ncdata_copy`.
         """
-        return NcAttribute(self.name, self.value)
+        return NcAttribute(self.name, self.value.copy())
+
+    def __eq__(self, other):
+        """Support simple equality testing."""
+        if not isinstance(other, NcAttribute):
+            result = NotImplemented
+        else:
+            result = self.name == other.name
+            if result:
+                v1 = self.value
+                v2 = other.value
+                result = (
+                    v1.shape == v2.shape
+                    and v1.dtype == v2.dtype
+                    and np.all(v1 == v2)
+                )
+        return result

--- a/lib/ncdata/_core.py
+++ b/lib/ncdata/_core.py
@@ -330,8 +330,8 @@ class NcData(_AttributeAccessMixin):
         """
         Copy self.
 
-        This duplicates structure with new ncdata core objects, but does not duplicate
-        data arrays.  See :func:`ncdata.utils.ncdata_copy`.
+        This duplicates structure with all-new ncdata core objects, but does not
+        duplicate variable data arrays.  See :func:`ncdata.utils.ncdata_copy`.
         """
         from ncdata.utils import ncdata_copy
 
@@ -479,7 +479,7 @@ class NcVariable(_AttributeAccessMixin):
         """
         Copy self.
 
-        Does not duplicate arrays oin data or attribute content.
+        Does not duplicate arrays in data content.
         See :func:`ncdata.utils.ncdata_copy`.
         """
         from ncdata.utils._copy import _attributes_copy
@@ -583,12 +583,7 @@ class NcAttribute:
         return repr(self)
 
     def copy(self):
-        """
-        Copy self.
-
-        Does not duplicate array content.
-        See :func:`ncdata.utils.ncdata_copy`.
-        """
+        """Copy self, including any array value content."""
         return NcAttribute(self.name, self.value.copy())
 
     def __eq__(self, other):

--- a/lib/ncdata/utils/_copy.py
+++ b/lib/ncdata/utils/_copy.py
@@ -15,7 +15,7 @@ def ncdata_copy(ncdata: NcData) -> NcData:
     Return a copy of the data.
 
     The operation makes fresh copies of all ncdata objects, but does not copy arrays in
-    either variable data or attribute values.
+    variable data.
 
     Parameters
     ----------

--- a/lib/ncdata/utils/_copy.py
+++ b/lib/ncdata/utils/_copy.py
@@ -14,8 +14,8 @@ def ncdata_copy(ncdata: NcData) -> NcData:
     """
     Return a copy of the data.
 
-    The operation makes fresh copies of all ncdata objects, but does not copy arrays in
-    variable data.
+    The operation makes fresh copies of all ncdata objects, but does not copy variable
+    data arrays.
 
     Parameters
     ----------

--- a/requirements/readthedocs.yml
+++ b/requirements/readthedocs.yml
@@ -4,13 +4,15 @@ channels:
   - conda-forge
 
 dependencies:
-  - netCDF4>=1.4
-  - numpy <2.0
   - iris
-  - xarray
-  - filelock
   - iris-sample-data
+  - filelock
+  - netCDF4>=1.4
+  - numpy
+  - pip
+  - pydata-sphinx-theme
   - pytest
+  - python<3.13
   - sphinx
   - sphinxcontrib-napoleon
-  - pydata-sphinx-theme
+  - xarray

--- a/tests/unit/core/test_AttributeAccessMixin.py
+++ b/tests/unit/core/test_AttributeAccessMixin.py
@@ -21,7 +21,7 @@ class Test_AttributeAccesses:
     def test_gettattr(self, sample_object):
         content = np.array([1, 2])
         sample_object.attributes.add(NcAttribute("x", content))
-        assert sample_object.get_attrval("x") is content
+        assert np.all(sample_object.get_attrval("x") == content)
 
     def test_getattr_absent(self, sample_object):
         # Check that fetching a non-existent attribute returns None.
@@ -30,15 +30,15 @@ class Test_AttributeAccesses:
     def test_setattr(self, sample_object):
         content = np.array([1, 2])
         sample_object.set_attrval("x", content)
-        assert sample_object.attributes["x"].value is content
+        assert np.all(sample_object.attributes["x"].value == content)
 
     def test_setattr__overwrite(self, sample_object):
         content = np.array([1, 2])
         sample_object.set_attrval("x", content)
-        assert sample_object.attributes["x"].value is content
+        assert np.all(sample_object.attributes["x"].value == content)
         sample_object.set_attrval("x", "replaced")
         assert list(sample_object.attributes.keys()) == ["x"]
-        assert sample_object.attributes["x"].value == "replaced"
+        assert np.all(sample_object.attributes["x"].value == "replaced")
 
     def test_setattr_getattr_none(self, sample_object):
         # Check behaviour when an attribute is given a Python value of 'None'.

--- a/tests/unit/core/test_NcAttribute.py
+++ b/tests/unit/core/test_NcAttribute.py
@@ -217,3 +217,17 @@ class Test_NcAttribute__eq__:
         assert attr1.value.dtype == "<U4"
 
     # NOTE: **not** testing a vector of multiple strings, since this has no function at present
+
+
+class Test_NcAttribute__value_assign:
+    def test_set(self, datatype, structuretype):
+        attr = NcAttribute("x", None)
+
+        set_value = attrvalue(datatype, structuretype)
+        attr.value = set_value
+
+        expected_array = np.asanyarray(set_value)
+        assert isinstance(attr.value, np.ndarray)
+        assert attr.value.dtype == expected_array.dtype
+        assert attr.value.shape == expected_array.shape
+        assert np.all(attr.value == expected_array)

--- a/tests/unit/core/test_NcDimension.py
+++ b/tests/unit/core/test_NcDimension.py
@@ -69,3 +69,37 @@ class Test_NcDimension_copy:
         assert result.name == sample.name
         assert result.size == sample.size
         assert result.unlimited == sample.unlimited
+
+
+class Test_NcDimension_eq:
+    @pytest.fixture(params=["isunlimited", "notunlimited"])
+    def unlimited(self, request):
+        return request.param == "isunlimited"
+
+    @pytest.fixture(params=[0, 3])
+    def size(self, request):
+        return request.param
+
+    @pytest.fixture()
+    def refdim(self, unlimited, size):
+        return NcDimension(name="ref_name", size=size, unlimited=unlimited)
+
+    def test_eq(self, refdim, size, unlimited):
+        thisdim = NcDimension("ref_name", size=size, unlimited=unlimited)
+        assert thisdim == refdim
+
+    def test_noneq_name(self, refdim, size, unlimited):
+        thisdim = NcDimension("other_name", size=size, unlimited=unlimited)
+        assert thisdim != refdim
+
+    def test_noneq_size(self, refdim, size, unlimited):
+        if unlimited:
+            pytest.skip("unsupported case")
+        thisdim = NcDimension("ref_name", size=7)
+        assert thisdim != refdim
+
+    def test_noneq_unlim(self, refdim, size, unlimited):
+        if size == 0:
+            pytest.skip("unsupported case")
+        thisdim = NcDimension("ref_name", size=size, unlimited=not unlimited)
+        assert thisdim != refdim

--- a/tests/unit/utils/test_ncdata_copy.py
+++ b/tests/unit/utils/test_ncdata_copy.py
@@ -78,19 +78,35 @@ class Test:
         result = ncdata_copy(sample)
         assert not differences_or_duplicated_objects(sample, result)
 
-    def test_sample_data(self, sample):
-        # Check that data arrays are *not* copied, in both variables and attributes
-        arr1 = np.array([9.1, 7, 4])
-        sample.set_attrval("extra", arr1)
-        assert sample.attributes["extra"].value is arr1
-
+    def test_sample_variable_data(self, sample):
+        # Check that data arrays are *not* copied
         result = ncdata_copy(sample)
 
-        assert (
-            result.attributes["extra"].value
-            is sample.attributes["extra"].value
-        )
         data_arr = sample.variables["a"].data
         assert result.variables["a"].data is data_arr
         assert result.groups["g1"].variables["a"].data is data_arr
         assert result.groups["g2"].variables["a"].data is data_arr
+
+    def test_sample_attribute_arraydata(self, sample):
+        # Check that attributes arrays *are* copied
+        arr1 = np.array([9.1, 7, 4])
+        sample.set_attrval("extra", arr1)
+        sva = sample.variables["a"]
+        sva.set_attrval("xx2", arr1)
+
+        result = ncdata_copy(sample)
+        rva = result.variables["a"]
+
+        assert (
+            result.attributes["extra"].value
+            is not sample.attributes["extra"].value
+        ) and np.all(
+            result.attributes["extra"].value
+            == sample.attributes["extra"].value
+        )
+
+        assert (
+            rva.attributes["xx2"].value is not sva.attributes["xx2"].value
+        ) and np.all(
+            rva.attributes["xx2"].value == sva.attributes["xx2"].value
+        )


### PR DESCRIPTION
Also one not-so subtle functional change : 
 - copying now duplicates arrays in attribute values (which changes tests a bit)

I also originally _tried_ to standardise attribute storage to 1-D arrays in all cases, and use `as_python_value` to present single values as scalars when requires.  
But this introduced a raft of problems, which I just don't have time to fix right now.
So left as-is for now : Attribute values are now always arrays, but it is still possible to have either scalar or 1-D.