### PR TITLE
Numpy v2 support

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          conda install --yes "numpy<2" pytest pytest-mock iris xarray filelock requests
+          conda install --yes numpy pytest pytest-mock iris xarray filelock requests
 
       - name: "Install *latest* Iris"
         run: |

--- a/tests/unit/core/test_NcAttribute.py
+++ b/tests/unit/core/test_NcAttribute.py
@@ -130,7 +130,9 @@ class Test_NcAttribute__str_repr:
             # All single values appear as scalars.
             value = np.array(value).flatten()[0]
 
-        value_repr = repr(value)
+        value_repr = str(value)
+        if "string" in datatype and not is_multiple:
+            value_repr = f"'{value_repr}'"
 
         is_non_numpy = "custom" in datatype or "none" in datatype
         if is_non_numpy or (is_multiple and "string" not in datatype):

--- a/tests/unit/utils/compare_nc_datasets/test_dataset_differences__additional.py
+++ b/tests/unit/utils/compare_nc_datasets/test_dataset_differences__additional.py
@@ -257,7 +257,7 @@ class Test_attribute_differences:
         assert errs == [
             (
                 '<object attributes> "a" attribute values differ : '
-                "array([0, 1, 2]) != array([0, 1])"
+                "[0, 1, 2] != [0, 1]"
             )
         ]
 
@@ -271,7 +271,7 @@ class Test_attribute_differences:
         assert errs == [
             (
                 '<object attributes> "a" attribute values differ : '
-                "array([1, 2, 3]) != array([  1,   2, 777])"
+                "[1, 2, 3] != [1, 2, 777]"
             )
         ]
 
@@ -293,7 +293,7 @@ class Test_attribute_differences:
         assert errs == [
             (
                 '<object attributes> "a" attribute values differ : '
-                "array([1., 2., 3.]) != array([ 1., nan,  3.])"
+                "[1.0, 2.0, 3.0] != [1.0, nan, 3.0]"
             )
         ]
 

--- a/tests/unit/utils/compare_nc_datasets/test_dataset_differences__mainfunctions.py
+++ b/tests/unit/utils/compare_nc_datasets/test_dataset_differences__mainfunctions.py
@@ -270,7 +270,7 @@ class TestCompareAttributes:
             value_string = "11"
         expected = [
             f'{self.location_string} "att1" attribute values differ : '
-            f"array({value_string}) != array(999)"
+            f"{value_string} != 999"
         ]
         check(errs, expected)
 


### PR DESCRIPTION
~See if this works ...~

Closes #90

OK this looks like a fairly big change, but it really only affects 
  1.  the error message construction in ``dataset_difference``
  2. the relevant unit tests
 
So, I think that can safely go in v0.2 release.

 * we probably do want this resolved within the scope of v0.2 release
  * ~but I'm not yet sure whether this impacts #109 , or should come before/after that~
     I don't think this really affects #109