### PR TITLE
Remove mistaken changelog inclusions.

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -23,42 +23,6 @@ Summary of key features by release number:
 
 .. towncrier release notes start
 
-Ncdata 0.3.0.dev4+dirty (2025-07-31)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Features
-^^^^^^^^
-
-- Added regular linkcheck gha. (`ISSUE#123 <https://github.com/pp-mo/ncdata/pull/123>`_)
-- Make :meth:`~ncdata.iris.to_iris` use the full iris load processing,
-  instead of :meth:`iris.fileformats.netcdf.loader.load_cubes`.
-  This means you can use load controls such as callbacks and constraints. (`ISSUE#131 <https://github.com/pp-mo/ncdata/pull/131>`_)
-
-
-Developer and Internal changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Switch to towncrier for whats-new management. (`ISSUE#116 <https://github.com/pp-mo/ncdata/pull/116>`_)
-
-
-Ncdata 0.3.0.dev4+dirty (2025-07-31)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Features
-^^^^^^^^
-
-- Added regular linkcheck gha. (`ISSUE#123 <https://github.com/pp-mo/ncdata/pull/123>`_)
-- Make :meth:`~ncdata.iris.to_iris` use the full iris load processing,
-  instead of :meth:`iris.fileformats.netcdf.loader.load_cubes`.
-  This means you can use load controls such as callbacks and constraints. (`ISSUE#131 <https://github.com/pp-mo/ncdata/pull/131>`_)
-
-
-Developer and Internal changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Switch to towncrier for whats-new management. (`ISSUE#116 <https://github.com/pp-mo/ncdata/pull/116>`_)
-
-
 v0.2.0
 ~~~~~~
 Overhauled data manipulation APIs.  Expanded and improved documentation.


### PR DESCRIPTION
Whoops, mistake included with #136 
The way the workflow is, if you do trial docs builds with 'make html', this makes changes to add a section in the changelog.
You need to remove those before you commit, but use of "git commit -a" means it's easy to miss.

FWIW this is also a good example of why we **_don't_** want to insist that all PRs should include a whatsnew
(which is a thing we could now add a CI check for).