### PR TITLE
Fix ncdump in docs, to avoid problems with pytest doctests.

### DIFF
--- a/docs/userdocs/getting_started/introduction.rst
+++ b/docs/userdocs/getting_started/introduction.rst
@@ -81,7 +81,7 @@ Simple example:
     >>> filepath = "./tmp.nc"
     >>> to_nc4(data, filepath)
 
-    >>> print(check_output("ncdump -h tmp.nc", shell=True).decode())  # doctest: +NORMALIZE_WHITESPACE
+    >>> ncdump("tmp.nc")  # utility calling 'ncdump -h' (not shown)
     netcdf tmp {
     dimensions:
        x = 3 ;

--- a/docs/userdocs/user_guide/howtos.rst
+++ b/docs/userdocs/user_guide/howtos.rst
@@ -16,6 +16,11 @@ i.e. wrong turns and gotchas, with brief descriptions of why.
     >>> from pprint import pprint
     >>> import numpy as np
     >>> from subprocess import check_output
+    >>> def ncdump(path):
+    ...     text = check_output(f'ncdump -h {path}', shell=True).decode()
+    ...     text = text.replace("\t", " " * 3)
+    ...     print(text)
+
 
 .. _howto_access:
 
@@ -351,7 +356,7 @@ Use the :func:`ncdata.netcdf4.to_nc4` function to write data to a file:
 
     >>> from ncdata.netcdf4 import to_nc4
     >>> to_nc4(data, filepath)
-    >>> print(check_output(f"ncdump -h {filepath}", shell=True).decode())  # doctest: +NORMALIZE_WHITESPACE
+    >>> ncdump(filepath)  # utility calling 'ncdump -h' (not shown)
     netcdf ...{
     dimensions:
        x = 3 ;


### PR DESCRIPTION
Since it seems that pytest doctests are "sometimes" (?intermitttently?!) ignoring the 'NORMALIZE_WHITESPACE' option