### PR TITLE
Fix indexing syntax not valid for Python<3.11.

### DIFF
--- a/docs/changelog_fragments/183.bug.rst
+++ b/docs/changelog_fragments/183.bug.rst
@@ -1,0 +1,1 @@
+Made indexing work with Python v3.10.

--- a/lib/ncdata/_core.py
+++ b/lib/ncdata/_core.py
@@ -500,8 +500,12 @@ class NcData(_AttributeAccessMixin):
 
         return Slicer(self, *dim_names)
 
-    def __getitem__(self, keys):  # noqa: D105
-        return self.slicer()[*keys]
+    def __getitem__(self, indices):  # noqa: D105
+        # N.B. Python [,,] syntax ensures there is only ever one argument,
+        #  either a single key or a tuple :
+        #    : [x] --> keys == x
+        #    : [x, y, ...] --> keys == (x, y, ...)
+        return self.slicer().__getitem__(indices)
 
     # Define equality in terms of dataset comparison utility
     def __eq__(self, other):  # noqa: D105

--- a/tests/unit/core/test_NcData.py
+++ b/tests/unit/core/test_NcData.py
@@ -4,7 +4,6 @@ There is almost no behaviour, but we can test some constructor usages.
 """
 
 import pytest
-
 from ncdata import NcData, NcDimension, NcVariable
 
 

--- a/tests/unit/core/test_NcData.py
+++ b/tests/unit/core/test_NcData.py
@@ -3,6 +3,8 @@
 There is almost no behaviour, but we can test some constructor usages.
 """
 
+import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 
 
@@ -99,17 +101,28 @@ class Test_NcVariable_slicer:
 
 class Test_NcVariable_getitem:
     # check that data[*keys] calls data.slicer[*keys]
-    def test(self, mocker):
+    @pytest.mark.parametrize(
+        "multiple_indices", [False, True], ids=["oneIndex", "multiIndex"]
+    )
+    def test(self, mocker, multiple_indices):
         from ncdata.utils import Slicer
 
         ncdata1 = NcData()
 
-        dim_keys = (1, 2, 3)  # N.B. not actually acceptable for a real usage
         mock_slicer = mocker.MagicMock(spec=Slicer)
         called = mocker.patch(
             "ncdata._core.NcData.slicer", return_value=mock_slicer
         )
-        result = ncdata1[*dim_keys]
+        if multiple_indices:
+            # Index with multiple keys, which should be passed as a tuple
+            # Slightly awkward code, because the "[*keys]" syntax is only valid from
+            #  Python >=3.11
+            result = ncdata1[1, 2, 3]
+            dim_keys = (1, 2, 3)
+        else:
+            # Index with a single key: should be passed as-is
+            dim_keys = slice(0, 3)
+            result = ncdata1[dim_keys]
 
         assert called.call_args_list == [mocker.call()]
         assert mock_slicer.__getitem__.call_args_list == [


### PR DESCRIPTION
Closes #183 

Just stop using the "[*keys]" form.
I don't *think* further testing of direct indexng of NcData is required:
We are relying on a chain of logic by which we ensure that `data[*keys]` is equivalent to `data.slicer()[*keys]` for any indexes.  I now have extended testing to both one and multiple keys, because these are effectively separate cases.