### PR TITLE
Update Python version requirements, and document.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,6 +27,20 @@ jobs:
       matrix:
         session: ["tests", "doctests-docs", "doctests-api"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - session: "doctests-docs"
+            python-version: "3.10"
+          - session: "doctests-docs"
+            python-version: "3.11"
+          - session: "doctests-docs"
+            python-version: "3.12"
+          - session: "doctests-api"
+            python-version: "3.10"
+          - session: "doctests-api"
+            python-version: "3.11"
+          - session: "doctests-api"
+            python-version: "3.12"
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,13 +51,6 @@ jobs:
         run: |
           conda install --yes numpy pytest pytest-mock iris xarray filelock requests zarr aiohttp fsspec
 
-      - name: "Install *latest* Iris"
-        run: |
-          git clone https://github.com/SciTools/iris.git ./iris
-          cd iris
-          pip install -e .
-          cd ..
-
       - name: "Install repo-under-test"
         run: |
           python -m pip install --no-deps --editable .

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         session: ["tests", "doctests-docs", "doctests-api"]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/docs/details/interface_support.rst
+++ b/docs/details/interface_support.rst
@@ -101,7 +101,7 @@ masked data to NaNs.
 Iris Compatibility
 ------------------
 The `Continuous Integration testing on GitHub`_ tests against the
-latest-current "main" branch of Iris.
+latest release of Iris.
 
 Ncdata is compatible with iris >= v3.7.0
 see : `support added in v3.7.0 <https://scitools-iris.readthedocs.io/en/stable/whatsnew/3.7.html#internal>`_

--- a/docs/details/interface_support.rst
+++ b/docs/details/interface_support.rst
@@ -1,7 +1,11 @@
 .. _interface_support:
 
-Support for Interface Packages
-==============================
+Support for Interfaces and Dependencies
+=======================================
+
+Python Compatibility
+--------------------
+NcData currently supports Python >= 3.10, and is tested against 3.10, 3.11, 3.12 and 3.13.
 
 NetCDF4 Compatibility
 ---------------------
@@ -94,8 +98,8 @@ masked data to NaNs.
     See : `issue#66 <https://github.com/pp-mo/ncdata/issues/66>`_
 
 
-Iris Features
--------------
+Iris Compatibility
+------------------
 The `Continuous Integration testing on GitHub`_ tests against the
 latest-current "main" branch of Iris.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "Patrick Peglar", email = "patrick.peglar@metoffice.gov.uk"},
 ]
 description = "Abstract NetCDF data objects, providing fast data transfer between analysis packages."
-requires-python = ">=3.7, <3.14"
+requires-python = ">=3.10"
 keywords = [
     "cf-metadata",
     "data-analysis",
@@ -33,9 +33,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/integration/test_zarr_to_iris.py
+++ b/tests/integration/test_zarr_to_iris.py
@@ -8,7 +8,6 @@ import iris
 import pytest
 import xarray as xr
 import zarr
-
 from ncdata.iris_xarray import cubes_from_xarray as conversion_func
 
 zarr_major_version = int(zarr.__version__.split(".")[0])

--- a/tests/integration/test_zarr_to_iris.py
+++ b/tests/integration/test_zarr_to_iris.py
@@ -7,8 +7,11 @@ import fsspec
 import iris
 import pytest
 import xarray as xr
+import zarr
 
 from ncdata.iris_xarray import cubes_from_xarray as conversion_func
+
+zarr_major_version = int(zarr.__version__.split(".")[0])
 
 
 def _return_kwargs():
@@ -52,6 +55,9 @@ def test_load_zarr2_local():
     _run_checks(cube)
 
 
+@pytest.mark.skipif(
+    zarr_major_version < 3, reason="Zarr3 file not supported by zarr v2."
+)
 def test_load_zarr3_local():
     """Test loading a Zarr3 store from local FS."""
     zarr_path = (
@@ -97,6 +103,9 @@ _S3_accessible = all(
 )
 
 
+@pytest.mark.skipif(
+    zarr_major_version < 3, reason="Zarr3 file not supported by zarr v2."
+)
 @pytest.mark.skipif(not _S3_accessible, reason="S3 url not accessible")
 def test_load_remote_zarr():
     """Test loading a remote Zarr store.

--- a/tests/integration/test_zarr_to_iris.py
+++ b/tests/integration/test_zarr_to_iris.py
@@ -7,6 +7,7 @@ import fsspec
 import iris
 import pytest
 import xarray as xr
+
 from ncdata.iris_xarray import cubes_from_xarray as conversion_func
 
 
@@ -88,7 +89,12 @@ S3_TEST_PATH = (
     "https://uor-aces-o.s3-ext.jc.rl.ac.uk/"
     "esmvaltool-zarr/pr_Amon_CNRM-ESM2-1_02Kpd-11_r1i1p2f2_gr_200601-220112.zarr3"
 )
-_S3_accessible = _is_url_ok(S3_TEST_PATH)
+
+# Check 3 files, as we apparently sometimes get 'partial success'
+_S3_accessible = all(
+    _is_url_ok(S3_TEST_PATH + subpath)
+    for subpath in ["", "/.zattrs", "/.zmetadata"]
+)
 
 
 @pytest.mark.skipif(not _S3_accessible, reason="S3 url not accessible")

--- a/tests/unit/xarray/test_to_xarray.py
+++ b/tests/unit/xarray/test_to_xarray.py
@@ -12,9 +12,9 @@ covered by the generic 'roundtrip' testcases.
 import dask.array as da
 import numpy as np
 import pytest
-
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.xarray import to_xarray
+
 from tests import MonitoredArray
 
 

--- a/tests/unit/xarray/test_to_xarray.py
+++ b/tests/unit/xarray/test_to_xarray.py
@@ -12,9 +12,9 @@ covered by the generic 'roundtrip' testcases.
 import dask.array as da
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.xarray import to_xarray
-
 from tests import MonitoredArray
 
 
@@ -61,7 +61,10 @@ def test_real_nocopy():
 
     # Check that the data content is  the *SAME ARRAY*
     xr_data = xrds.variables["var_x"]._data
-    assert xr_data is real_numpy_data
+    # There may be a wrapper object, for some versions of xarray,
+    #  so test by modifying the original + check that the result tracks it.
+    real_numpy_data[-1] = 777
+    assert np.all(xr_data == real_numpy_data)
 
 
 @pytest.mark.parametrize("scaleandoffset", ["WITHscaling", "NOscaling"])


### PR DESCRIPTION
Closes #186 
Intended as preparation for a v0.3.2 release, which will "unpin" Python 3.10

N.B. for now, testing on all of 3.10/3.11/3.12/3.13
Can't conveniently do 3.14 until Iris supports it.