### PR TITLE
Pytestless doctests 2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: "Run doctests: Docs"
         if: matrix.session == 'doctests-docs'
         run: |
-          tools/run_doctests.py -v $(find ./docs -iname '*.rst')
+          tools/run_doctests.py -v "./docs/**/*.rst"
 
       - name: "Run doctests: API"
         if: matrix.session == 'doctests-api'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,11 +90,9 @@ jobs:
       - name: "Run doctests: Docs"
         if: matrix.session == 'doctests-docs'
         run: |
-          cd docs
-          pytest --doctest-glob="*.rst" --doctest-continue-on-failure
+          tools/run_doctests.py $(find ./docs -iname '*.rst') -va
 
       - name: "Run doctests: API"
         if: matrix.session == 'doctests-api'
         run: |
-          cd lib
-          pytest --doctest-modules --doctest-continue-on-failure
+          tools/run_doctests.py ncdata -va

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,9 +90,9 @@ jobs:
       - name: "Run doctests: Docs"
         if: matrix.session == 'doctests-docs'
         run: |
-          tools/run_doctests.py $(find ./docs -iname '*.rst') -va
+          tools/run_doctests.py -v $(find ./docs -iname '*.rst')
 
       - name: "Run doctests: API"
         if: matrix.session == 'doctests-api'
         run: |
-          tools/run_doctests.py ncdata -va
+          tools/run_doctests.py -v -mr ncdata

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          conda install --yes numpy pytest pytest-mock iris xarray<2026.03 filelock requests zarr aiohttp fsspec
+          conda install --yes numpy pytest pytest-mock iris "xarray<2026.03" filelock requests zarr aiohttp fsspec
 
       - name: "Install repo-under-test"
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          conda install --yes numpy pytest pytest-mock iris xarray filelock requests zarr aiohttp fsspec
+          conda install --yes numpy pytest pytest-mock iris xarray<2026.03 filelock requests zarr aiohttp fsspec
 
       - name: "Install repo-under-test"
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          conda install --yes numpy pytest pytest-mock iris "xarray<2026.03" filelock requests zarr aiohttp fsspec
+          conda install --yes numpy pytest pytest-mock iris "xarray<2026.03" cftime filelock requests zarr aiohttp fsspec
 
       - name: "Install repo-under-test"
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,14 +27,14 @@ repos:
     -   id: no-commit-to-branch
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.2"
+    rev: "v2.4.3"
     hooks:
     -   id: codespell
         types_or: [asciidoc, python, markdown, rst]
         additional_dependencies: [tomli]
 
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
     -   id: black
         pass_filenames: false
@@ -47,7 +47,7 @@ repos:
         types: [file, python]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 8.0.1
+    rev: 9.0.0b5
     hooks:
     -   id: isort
         name: isort (python)

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: mambaforge-4.10
+    python: miniforge3-26.3
   jobs:
     # Content here largely copied from Iris
     #  see : https://github.com/SciTools/iris/pull/4855

--- a/docs/changelog_fragments/173.dev.rst
+++ b/docs/changelog_fragments/173.dev.rst
@@ -1,0 +1,1 @@
+Fix xarray 2025.09.1 problem.

--- a/docs/changelog_fragments/174.doc.rst
+++ b/docs/changelog_fragments/174.doc.rst
@@ -1,0 +1,1 @@
+Document how to create a developer installation.

--- a/docs/changelog_fragments/175.dev.rst
+++ b/docs/changelog_fragments/175.dev.rst
@@ -1,0 +1,1 @@
+Pinned python for now, since 3.14 causes problems with Iris (notably).

--- a/docs/userdocs/getting_started/introduction.rst
+++ b/docs/userdocs/getting_started/introduction.rst
@@ -40,7 +40,7 @@ and :attr:`~ncdata.NcData.attributes`:
     >>> data
     <ncdata._core.NcData object at ...>
     >>> print(data)
-    <NcData: myname
+    <NcData: urrgh
     >
 
     >>> dim = NcDimension("x", 3)

--- a/lib/ncdata/utils/_dim_indexing.py
+++ b/lib/ncdata/utils/_dim_indexing.py
@@ -35,7 +35,7 @@ def index_by_dimensions(
         >>> data = NcData(dimensions=[NcDimension(nn, 10) for nn in ("time", "levels")])
 
     >>> data1 = index_by_dimensions(data, time=slice(0, 10))  # equivalent to [:10]
-    >>> data2 = index_by_dimensions(data, levels=[1,2,5])
+    >>> data2 = index_by_dimension(data, levels=[1,2,5])
     >>> data3 = index_by_dimensions(data, time=3, levels=slice(2, 10, 3))
 
     Notes

--- a/tests/data_testcase_schemas.py
+++ b/tests/data_testcase_schemas.py
@@ -525,6 +525,8 @@ BAD_LOADSAVE_TESTCASES = {
             # """
             "small_rotPole_precipitation",
             "small_FC_167",
+            # And this one, which has recently acquired a problem?
+            "test_monotonic_coordinate",
         ],
         # Xarray can save ~anything
         "save": [r"test_monotonic_coordinate"],

--- a/tools/check_doctest.py
+++ b/tools/check_doctest.py
@@ -3,7 +3,11 @@ from run_doctests import run_doctest_paths, _parser, parserargs_as_kwargs
 
 # tstargs = ['ncdata', '-da', '--options', 'verbose=1']
 
-tstargs = ['/home/users/patrick.peglar/git/ncdata/docs/userdocs/user_guide/howtos.rst', '--options', 'verbose=1']
+tstargs = [
+    "/home/users/patrick.peglar/git/ncdata/docs/userdocs/user_guide/howtos.rst",
+    "--options",
+    "verbose=1",
+]
 
 
 args = _parser.parse_args(tstargs)

--- a/tools/check_doctest.py
+++ b/tools/check_doctest.py
@@ -1,0 +1,18 @@
+from doctest import ELLIPSIS as ELLIPSIS_FLAG
+from run_doctests import run_doctest_paths, _parser, parserargs_as_kwargs
+
+# tstargs = ['ncdata', '-da', '--options', 'verbose=1']
+
+tstargs = ['/home/users/patrick.peglar/git/ncdata/docs/userdocs/user_guide/howtos.rst', '--options', 'verbose=1']
+
+
+args = _parser.parse_args(tstargs)
+kwargs = parserargs_as_kwargs(args)
+# if not "options" in kwargs:
+#     kwargs["options"] = "ELLIPSIS=1"
+run_doctest_paths(**kwargs)
+
+#
+# Currently good:
+# $ tools/run_doctests.py docs/userdocs/getting_started/introduction.rst -o "optionflags=8"
+# $ tools/run_doctests.py docs/userdocs/getting_started/*.rst -vo "optionflags=8"

--- a/tools/check_doctest.py
+++ b/tools/check_doctest.py
@@ -15,6 +15,8 @@ from run_doctests import run_doctest_paths, _parser, parserargs_as_kwargs
 
 tstargs = ["-mvr", "iris._combine", "-o", "raise_on_error=True"]
 
+tstargs = ["-r", "../docs/userdocs/**/*.rst", "-e", "started.rst"]
+
 args = _parser.parse_args(tstargs)
 kwargs = parserargs_as_kwargs(args)
 # if not "options" in kwargs:

--- a/tools/check_doctest.py
+++ b/tools/check_doctest.py
@@ -3,12 +3,13 @@ from run_doctests import run_doctest_paths, _parser, parserargs_as_kwargs
 
 # tstargs = ['ncdata', '-da', '--options', 'verbose=1']
 
-tstargs = [
-    "/home/users/patrick.peglar/git/ncdata/docs/userdocs/user_guide/howtos.rst",
-    "--options",
-    "verbose=1",
-]
+# tstargs = [
+#     "/home/users/patrick.peglar/git/ncdata/docs/userdocs/user_guide/howtos.rst",
+#     "--options",
+#     "verbose=1",
+# ]
 
+tstargs = ["-mvr", "ncdata.iris"]
 
 args = _parser.parse_args(tstargs)
 kwargs = parserargs_as_kwargs(args)

--- a/tools/check_doctest.py
+++ b/tools/check_doctest.py
@@ -9,7 +9,11 @@ from run_doctests import run_doctest_paths, _parser, parserargs_as_kwargs
 #     "verbose=1",
 # ]
 
-tstargs = ["-mvr", "ncdata.iris"]
+# tstargs = ["-mvr", "iris.coords", "-o", "verbose=True"]
+
+# tstargs = ["-mvr", "iris.tests.unit.fileformats.netcdf", "-e", "attribute_handlers"]
+
+tstargs = ["-mvr", "iris._combine", "-o", "raise_on_error=True"]
 
 args = _parser.parse_args(tstargs)
 kwargs = parserargs_as_kwargs(args)

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+import argparse
+import doctest
+import importlib
+from pathlib import Path
+import pkgutil
+import sys
+
+def list_modules_recursive(module_importname: str, include_private: bool = False):
+    module_names = [module_importname]
+    # Identify module from its import path (no import -> fail back to caller)
+    module = importlib.import_module(module_importname)
+    # Get the filepath of the module base directory
+    module_filepath = str(Path(module.__file__).parent)
+    for _, name, ispkg in pkgutil.iter_modules([module_filepath]):
+        if not name.startswith("_") or include_private:
+            submodule_name = module_importname + "." + name
+            module_names.append(submodule_name)
+            if ispkg:
+                module_names.extend(list_modules_recursive(
+                    submodule_name, include_private=include_private
+                ))
+    # I don't know why there are duplicates, but there can be.
+    result = []
+    for name in module_names:
+        if name not in result:
+            # For some reason, some things get listed twice.
+            result.append(name)
+
+    return result
+
+
+def process_options(opt_str:str) -> dict[str, str]:
+    # First collapse spaces around equals signs."
+    while " =" in opt_str:
+        opt_str = opt_str.replace(" =", "=")
+    while "= " in opt_str:
+        opt_str = opt_str.replace("= ", "=")
+    # Collapse (remaining) duplicate spaces
+    while "  " in opt_str:
+        opt_str = opt_str.replace("  ", " ")
+    # Split on spaces, and split each one on "=" expecting a simple name=val form
+    opts_dict = {}
+    if opt_str:  # N.B. to avoid unexpected behaviour from "".split()
+        for setting_str in opt_str.split(" "):
+            try:
+                name, val = setting_str.split("=")
+
+                # Translate certain things (but do not exec!!)
+                bool_vals = {"true": True, "false": False}
+                if val.isdigit():
+                    val = int(val)
+                elif val.lower() in bool_vals:
+                    val = bool_vals[val.lower()]
+
+            except ValueError:
+                msg = f"Invalid option setting {setting_str!r}, expected 'name=value' only."
+                raise ValueError(msg)
+
+            opts_dict[name] = val
+
+    return opts_dict
+
+
+def run_doctest_paths(
+    paths: list[str],
+    opts_str:str,
+    verbose:bool = False,
+    dry_run:bool=False,
+    do_all:bool=False
+):
+    if verbose:
+        print(
+            "RUNNING run_doctest("
+            f"paths={paths!r}"
+            f", opts_str={opts_str!r}"
+            f", verbose={verbose!r}"
+            f", dry_run={dry_run!r}"
+            f", do_all={do_all!r}"
+            ")"
+        )
+    if dry_run:
+        verbose = True
+    opts_kwargs = process_options(opts_str)
+    finished = False
+    try:
+        module_paths = []
+        for path in paths:
+            module_paths += list_modules_recursive(path, include_private=do_all)
+        for path in module_paths:
+            if verbose:
+                print(f"\ndoctest.testmod: {path!r}")
+            if not dry_run:
+                module = importlib.import_module(path)
+                doctest.testmod(module, **opts_kwargs)
+        finished = True
+    except (ImportError, ModuleNotFoundError, TypeError):
+        # TODO: this list is "awkward" !
+        pass
+
+    if not finished:
+        # Module search failed : treat paths as (documentation) filepaths instead
+        # Fix options : TODO this is not very clever, think of something better??
+        if not "module_relative" in opts_kwargs:
+            opts_kwargs["module_relative"] = False
+        if not "optionflags" in opts_kwargs:
+            default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+            opts_kwargs["optionflags"] = default_flags
+        for path in paths:
+            if verbose:
+                print(f"\ndoctest.testfile: {path!r}")
+            if not dry_run:
+                doctest.testfile(path, **opts_kwargs)
+
+
+_parser = argparse.ArgumentParser(
+    prog="run_doctests",
+    description="Runs doctests in docs files, or docstrings in packages."
+)
+_parser.add_argument(
+    "-o", "--options", nargs="?",
+    help="doctest options settings (as a string).",
+    type=str, default=""
+)
+_parser.add_argument(
+    "-v", "--verbose", action="store_true",
+    help="Show actions."
+)
+_parser.add_argument(
+    "-d", "--dryrun", action="store_true",
+    help="Only print the names of modules/files which *would* be tested."
+)
+_parser.add_argument(
+    "-a", "--all", action="store_true",
+    help="If set, include private files/modules "
+)
+_parser.add_argument(
+    "paths", nargs="*",
+    help="docs filepaths, or module paths (not both).",
+    type=str, default=[]
+)
+
+def parserargs_as_kwargs(args):
+    return dict(
+        paths=args.paths,
+        opts_str=args.options,
+        verbose=args.verbose,
+        dry_run=args.dryrun,
+        do_all=args.all
+    )
+
+
+if __name__ == '__main__':
+    args = _parser.parse_args(sys.argv[1:])
+    kwargs = parserargs_as_kwargs(args)
+    run_doctest_paths(**kwargs)

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -128,6 +128,8 @@ def run_doctest_paths(
         # Fix options : TODO this is not very clever, think of something better??
         if not "module_relative" in option_kwargs:
             option_kwargs["module_relative"] = False
+        if not "verbose" in option_kwargs:
+            option_kwargs["verbose"] = False
         if not "optionflags" in option_kwargs:
             default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
             option_kwargs["optionflags"] = default_flags
@@ -151,6 +153,8 @@ def run_doctest_paths(
                     n_total_fails += n_fails
                     n_total_tests += n_tests
                     n_paths_tested += 1
+                    if n_fails:
+                        print(f"\nERRORS from doctests in path: {arg}\n")
                 except Exception as exc:
                     op_fail = exc
 

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pkgutil
 import sys
 
-def list_modules_recursive(module_importname: str, include_private: bool = False):
+
+def list_modules_recursive(
+    module_importname: str, include_private: bool = False
+):
     module_names = [module_importname]
     # Identify module from its import path (no import -> fail back to caller)
     module = importlib.import_module(module_importname)
@@ -17,9 +20,11 @@ def list_modules_recursive(module_importname: str, include_private: bool = False
             submodule_name = module_importname + "." + name
             module_names.append(submodule_name)
             if ispkg:
-                module_names.extend(list_modules_recursive(
-                    submodule_name, include_private=include_private
-                ))
+                module_names.extend(
+                    list_modules_recursive(
+                        submodule_name, include_private=include_private
+                    )
+                )
     # I don't know why there are duplicates, but there can be.
     result = []
     for name in module_names:
@@ -30,7 +35,7 @@ def list_modules_recursive(module_importname: str, include_private: bool = False
     return result
 
 
-def process_options(opt_str:str) -> dict[str, str]:
+def process_options(opt_str: str) -> dict[str, str]:
     # First collapse spaces around equals signs."
     while " =" in opt_str:
         opt_str = opt_str.replace(" =", "=")
@@ -64,10 +69,10 @@ def process_options(opt_str:str) -> dict[str, str]:
 
 def run_doctest_paths(
     paths: list[str],
-    opts_str:str,
-    verbose:bool = False,
-    dry_run:bool=False,
-    do_all:bool=False
+    opts_str: str,
+    verbose: bool = False,
+    dry_run: bool = False,
+    do_all: bool = False,
 ):
     if verbose:
         print(
@@ -86,7 +91,9 @@ def run_doctest_paths(
     try:
         module_paths = []
         for path in paths:
-            module_paths += list_modules_recursive(path, include_private=do_all)
+            module_paths += list_modules_recursive(
+                path, include_private=do_all
+            )
         for path in module_paths:
             if verbose:
                 print(f"\ndoctest.testmod: {path!r}")
@@ -115,30 +122,39 @@ def run_doctest_paths(
 
 _parser = argparse.ArgumentParser(
     prog="run_doctests",
-    description="Runs doctests in docs files, or docstrings in packages."
+    description="Runs doctests in docs files, or docstrings in packages.",
 )
 _parser.add_argument(
-    "-o", "--options", nargs="?",
+    "-o",
+    "--options",
+    nargs="?",
     help="doctest options settings (as a string).",
-    type=str, default=""
+    type=str,
+    default="",
 )
 _parser.add_argument(
-    "-v", "--verbose", action="store_true",
-    help="Show actions."
+    "-v", "--verbose", action="store_true", help="Show actions."
 )
 _parser.add_argument(
-    "-d", "--dryrun", action="store_true",
-    help="Only print the names of modules/files which *would* be tested."
+    "-d",
+    "--dryrun",
+    action="store_true",
+    help="Only print the names of modules/files which *would* be tested.",
 )
 _parser.add_argument(
-    "-a", "--all", action="store_true",
-    help="If set, include private files/modules "
+    "-a",
+    "--all",
+    action="store_true",
+    help="If set, include private files/modules ",
 )
 _parser.add_argument(
-    "paths", nargs="*",
+    "paths",
+    nargs="*",
     help="docs filepaths, or module paths (not both).",
-    type=str, default=[]
+    type=str,
+    default=[],
 )
+
 
 def parserargs_as_kwargs(args):
     return dict(
@@ -146,11 +162,11 @@ def parserargs_as_kwargs(args):
         opts_str=args.options,
         verbose=args.verbose,
         dry_run=args.dryrun,
-        do_all=args.all
+        do_all=args.all,
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = _parser.parse_args(sys.argv[1:])
     kwargs = parserargs_as_kwargs(args)
     run_doctest_paths(**kwargs)

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -8,23 +8,25 @@ import sys
 
 
 def list_modules_recursive(
-    module_importname: str, include_private: bool = False
+    module_importname: str, include_private: bool = True
 ):
     module_names = [module_importname]
     # Identify module from its import path (no import -> fail back to caller)
     module = importlib.import_module(module_importname)
     # Get the filepath of the module base directory
-    module_filepath = str(Path(module.__file__).parent)
-    for _, name, ispkg in pkgutil.iter_modules([module_filepath]):
-        if not name.startswith("_") or include_private:
-            submodule_name = module_importname + "." + name
-            module_names.append(submodule_name)
-            if ispkg:
-                module_names.extend(
-                    list_modules_recursive(
-                        submodule_name, include_private=include_private
+    module_filepath = Path(module.__file__)
+    if module_filepath.name == "__init__.py":
+        search_filepath = str(module_filepath.parent)
+        for _, name, ispkg in pkgutil.iter_modules([search_filepath]):
+            if not name.startswith("_") or include_private:
+                submodule_name = module_importname + "." + name
+                module_names.append(submodule_name)
+                if ispkg:
+                    module_names.extend(
+                        list_modules_recursive(
+                            submodule_name, include_private=include_private
+                        )
                     )
-                )
     # I don't know why there are duplicates, but there can be.
     result = []
     for name in module_names:
@@ -36,22 +38,17 @@ def list_modules_recursive(
 
 
 def process_options(opt_str: str) -> dict[str, str]:
-    # First collapse spaces around equals signs."
-    while " =" in opt_str:
-        opt_str = opt_str.replace(" =", "=")
-    while "= " in opt_str:
-        opt_str = opt_str.replace("= ", "=")
-    # Collapse (remaining) duplicate spaces
-    while "  " in opt_str:
-        opt_str = opt_str.replace("  ", " ")
-    # Split on spaces, and split each one on "=" expecting a simple name=val form
+    """Convert the "-o/--options" arg into a **kwargs for the doctest function call."""
+    # Remove all spaces (think they are never needed).
+    opt_str = opt_str.replace(" ", "")
+    # Split on commas, and split each one on "=" expecting a simple name=val form
     opts_dict = {}
-    if opt_str:  # N.B. to avoid unexpected behaviour from "".split()
-        for setting_str in opt_str.split(" "):
+    if opt_str:  # N.B. to avoid unexpected behaviour: "".split() --> [""]
+        for setting_str in opt_str.split(","):
             try:
                 name, val = setting_str.split("=")
 
-                # Translate certain things (but do not exec!!)
+                # Detect + translate numberic and boolean values.
                 bool_vals = {"true": True, "false": False}
                 if val.isdigit():
                     val = int(val)
@@ -69,55 +66,86 @@ def process_options(opt_str: str) -> dict[str, str]:
 
 def run_doctest_paths(
     paths: list[str],
-    opts_str: str,
+    paths_are_modules:bool = False,
+    recurse_modules: bool = False,
+    include_private_modules: bool = False,
+    option_kwargs: dict = {},
     verbose: bool = False,
     dry_run: bool = False,
-    do_all: bool = False,
+    stop_on_failure: bool = False,
 ):
+    n_total_fails, n_total_tests, n_paths_tested = 0, 0, 0
     if verbose:
         print(
             "RUNNING run_doctest("
             f"paths={paths!r}"
-            f", opts_str={opts_str!r}"
+            f", paths_are_modules={paths_are_modules!r}"
+            f", option_kwargs={option_kwargs!r}"
             f", verbose={verbose!r}"
             f", dry_run={dry_run!r}"
-            f", do_all={do_all!r}"
+            f", stop_on_failure={stop_on_failure!r}"
+            f", include_private={include_private_modules!r}"
             ")"
         )
     if dry_run:
         verbose = True
-    opts_kwargs = process_options(opts_str)
-    finished = False
-    try:
-        module_paths = []
-        for path in paths:
-            module_paths += list_modules_recursive(
-                path, include_private=do_all
-            )
-        for path in module_paths:
-            if verbose:
-                print(f"\ndoctest.testmod: {path!r}")
-            if not dry_run:
-                module = importlib.import_module(path)
-                doctest.testmod(module, **opts_kwargs)
-        finished = True
-    except (ImportError, ModuleNotFoundError, TypeError):
-        # TODO: this list is "awkward" !
-        pass
 
-    if not finished:
-        # Module search failed : treat paths as (documentation) filepaths instead
+    if paths_are_modules:
+        doctest_function = doctest.testmod
+        if recurse_modules:
+            module_paths = []
+            for path in paths:
+                module_paths += list_modules_recursive(
+                    path, include_private=include_private_modules
+                )
+            paths = module_paths
+
+    else:  # paths are filepaths
+        doctest_function = doctest.testfile
         # Fix options : TODO this is not very clever, think of something better??
-        if not "module_relative" in opts_kwargs:
-            opts_kwargs["module_relative"] = False
-        if not "optionflags" in opts_kwargs:
+        if not "module_relative" in option_kwargs:
+            option_kwargs["module_relative"] = False
+        if not "optionflags" in option_kwargs:
             default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
-            opts_kwargs["optionflags"] = default_flags
-        for path in paths:
-            if verbose:
-                print(f"\ndoctest.testfile: {path!r}")
-            if not dry_run:
-                doctest.testfile(path, **opts_kwargs)
+            option_kwargs["optionflags"] = default_flags
+
+    for path in paths:
+        if verbose:
+            print(f"\n-----\ndoctest.{doctest_function.__name__}: {path!r}")
+        if not dry_run:
+            if paths_are_modules:
+                arg = importlib.import_module(path)
+            else:
+                arg = path
+            n_fails, n_tests = doctest_function(arg, **option_kwargs)
+            n_total_fails += n_fails
+            n_total_tests += n_tests
+            n_paths_tested += 1
+            if n_total_fails > 0 and stop_on_failure:
+                break
+
+    if verbose or n_total_fails > 0:
+        # Print a final report
+        msgs = ["", "=====", "run_doctest: FINAL REPORT"]
+        if dry_run:
+            msgs += ["(DRY RUN: no actual tests)"]
+        elif stop_on_failure and n_total_fails > 0:
+            msgs += ["(FAIL FAST: stopped at first target with errors)"]
+
+        msgs += [
+            f"    paths tested    = {n_paths_tested}",
+            f"    tests completed = {n_total_tests}",
+            f"    errors          = {n_total_fails}",
+            ""
+        ]
+        if n_total_fails > 0:
+            msgs += ["FAILED."]
+        else:
+            msgs += ["OK."]
+
+        print('\n'.join(msgs))
+
+    return n_total_fails
 
 
 _parser = argparse.ArgumentParser(
@@ -125,15 +153,34 @@ _parser = argparse.ArgumentParser(
     description="Runs doctests in docs files, or docstrings in packages.",
 )
 _parser.add_argument(
+    "-m", "--module", action="store_true",
+    help="Paths are module paths (xx.yy.zz), instead of filepaths."
+)
+_parser.add_argument(
+    "-r",
+    "--recursive",
+    action="store_true",
+    help="If set, include submodules (only applies with -m).",
+)
+_parser.add_argument(
+    "-p",
+    "--publiconly",
+    action="store_true",
+    help="If set, exclude private modules (only applies with -m and -r)",
+)
+_parser.add_argument(
     "-o",
     "--options",
     nargs="?",
-    help="doctest options settings (as a string).",
+    help=(
+        "doctest function kwargs (string)"
+        ", e.g. \"report=False, raise_on_error=True, optionflags=8\"."
+    ),
     type=str,
     default="",
 )
 _parser.add_argument(
-    "-v", "--verbose", action="store_true", help="Show actions."
+    "-v", "--verbose", action="store_true", help="Show details of each action."
 )
 _parser.add_argument(
     "-d",
@@ -142,10 +189,10 @@ _parser.add_argument(
     help="Only print the names of modules/files which *would* be tested.",
 )
 _parser.add_argument(
-    "-a",
-    "--all",
+    "-f",
+    "--stop-on-fail",
     action="store_true",
-    help="If set, include private files/modules ",
+    help="If set, stop at the first path with an error (else continue to test all).",
 )
 _parser.add_argument(
     "paths",
@@ -159,14 +206,18 @@ _parser.add_argument(
 def parserargs_as_kwargs(args):
     return dict(
         paths=args.paths,
-        opts_str=args.options,
+        paths_are_modules=args.module,
+        recurse_modules=args.recursive,
+        include_private_modules=not args.publiconly,
+        option_kwargs=process_options(args.options),
         verbose=args.verbose,
         dry_run=args.dryrun,
-        do_all=args.all,
+        stop_on_failure=args.stop_on_fail,
     )
 
 
 if __name__ == "__main__":
     args = _parser.parse_args(sys.argv[1:])
     kwargs = parserargs_as_kwargs(args)
-    run_doctest_paths(**kwargs)
+    n_errs = run_doctest_paths(**kwargs)
+    exit(1 if n_errs > 0 else 0)

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -18,11 +18,10 @@ import warnings
 def list_modules_recursive(
     module_importname: str,
     include_private: bool = True,
-    exclude_fragments: list[str] = [],
 ) -> list[str]:
     """Find all the submodules of a given module.
 
-    Also filter with private and exclude controls.
+    Also filter out private modules, if selected.
     """
     module_names = [module_importname]
     # Identify module from its import path : N.B. fail --> return [module-path]
@@ -35,22 +34,18 @@ def list_modules_recursive(
 
     if error is None:
         # Add all sub-modules to the list
-        # Get the filepath of the module base directory
-        module_filepath = Path(str(module.__file__))
+        module_filepath = Path(str(module.__file__))  # Get filepath of module base
         if module_filepath.name == "__init__.py":
             for _, name, ispkg in pkgutil.iter_modules([module_filepath.parent]):
                 if name[:1] == "_" and not include_private:
                     continue
                 submodule_name = module_importname + "." + name
-                if any(match in submodule_name for match in exclude_fragments):
-                    continue
                 module_names.append(submodule_name)
                 if ispkg:
                     module_names.extend(
                         list_modules_recursive(
                             submodule_name,
                             include_private=include_private,
-                            exclude_fragments=exclude_fragments,
                         )
                     )
 
@@ -59,35 +54,27 @@ def list_modules_recursive(
 
 
 def list_filepaths_recursive(
-    file_spec: str, exclude_fragments: list[str] = []
+    file_spec: str,
 ) -> list[Path]:
     """Expand a filepath string, possibly containing globs, to a list of filepaths.
 
     Also filter with exclude controls.
     """
-    segments = file_spec.split("/")
-    i_wilds = [
-        index
-        for index, segment in enumerate(segments)
-        if any(char in segment for char in "*?[")
-    ]
-    if len(i_wilds) == 0:
+    if not any(c in file_spec for c in "?*["):
+        # when no globs, action the (single) filepath --> error if it doesn't exist
         found_paths = [Path(file_spec)]
     else:
-        i_first_wild = i_wilds[0]
-        # Split into a regular path prefix + the part including globs
-        base_path = Path("/".join(segments[:i_first_wild]))
-        glob_spec = "/".join(segments[i_first_wild:])
-        # expand with globs
-        found_paths = list(base_path.glob(glob_spec))
+        # split the path and do a glob --> list[Path]
+        path = Path(file_spec).absolute()  # make absolute so we can get a root part
+        base_pth = Path(path.root)
+        glob_path = path.relative_to(base_pth)
+        found_paths = base_pth.glob(glob_path)
 
-    # Also apply excludes to results
-    # NB there is NO "private" filtering for sourcefiles
+    # Apply excludes to results : NB no "private" option (unlike modules)
     found_paths = [
         path
         for path in found_paths
         if not path.is_dir()
-        and not any(match in str(path) for match in exclude_fragments)
     ]
     return found_paths
 
@@ -169,7 +156,7 @@ def run_doctest_paths(
                 module_paths += list_modules_recursive(
                     str(path),  # for modules, 'paths' are always strings anyway
                     include_private=include_private_modules,
-                    exclude_fragments=exclude_fragments,
+                    # exclude_fragments=exclude_fragments,
                 )
             paths = module_paths
     else:
@@ -178,11 +165,14 @@ def run_doctest_paths(
         filepaths = []
         for path in paths:
             filepaths += list_filepaths_recursive(
-                str(path), exclude_fragments=exclude_fragments
+                str(path) #, exclude_fragments=exclude_fragments
             )
         paths = filepaths
 
     for path in paths:
+        # filter with excludes
+        if any(frag in str(path) for frag in exclude_fragments):
+            continue
         if verbose:
             print(f"\n-----\ndoctest.{doctest_function.__name__}: {path}")
         if dry_run:
@@ -335,26 +325,21 @@ _parser.add_argument(
 )
 
 
-def parserargs_as_kwargs(args):
-    return dict(
-        paths=args.paths,
-        paths_are_modules=args.module,
-        recurse_modules=args.recurse,
-        include_private_modules=not args.publiconly,
-        exclude_fragments=args.exclude or [],
-        doctest_kwargs=process_options(args.options, args.module),
-        verbose=args.verbose,
-        dry_run=args.dryrun,
-        stop_on_failure=args.stop_on_fail,
-    )
-
-
 if __name__ == "__main__":
     args = _parser.parse_args(sys.argv[1:])
     if not args.paths:
         _parser.print_help()
     else:
-        kwargs = parserargs_as_kwargs(args)
-        n_errs = run_doctest_paths(**kwargs)
+        n_errs = run_doctest_paths(
+            paths=args.paths,
+            paths_are_modules=args.module,
+            recurse_modules=args.recurse,
+            include_private_modules=not args.publiconly,
+            exclude_fragments=args.exclude or [],
+            doctest_kwargs=process_options(args.options, args.module),
+            verbose=args.verbose,
+            dry_run=args.dryrun,
+            stop_on_failure=args.stop_on_fail,
+        )
         if n_errs > 0:
             exit(1)

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -95,7 +95,9 @@ def list_filepaths_recursive(
     return result
 
 
-def process_options(opt_str: str, paths_are_modules: bool = True) -> dict[str, str]:
+def process_options(
+    opt_str: str, paths_are_modules: bool = True
+) -> dict[str, str]:
     """Convert the "-o/--options" arg into a **kwargs for the doctest function call."""
     # Remove all spaces (think they are never needed).
     opt_str = opt_str.replace(" ", "")
@@ -183,7 +185,9 @@ def run_doctest_paths(
         doctest_function = doctest.testfile
         filepaths = []
         for path in paths:
-            filepaths += list_filepaths_recursive(path, exclude_matches=exclude_matches)
+            filepaths += list_filepaths_recursive(
+                path, exclude_matches=exclude_matches
+            )
         paths = filepaths
 
     for path in paths:
@@ -314,7 +318,10 @@ _parser.add_argument(
     default="",
 )
 _parser.add_argument(
-    "-v", "--verbose", action="store_true", help="show details of each operation."
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="show details of each operation.",
 )
 _parser.add_argument(
     "-d",

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -34,18 +34,23 @@ def list_modules_recursive(
         print(f"\n\nIMPORT FAILED: {module_importname}\n  error: {exc}")
 
     if module_path is not None:
-        module_names.extend([
-            mod_info.name
-            for mod_info in pkgutil.walk_packages(
-                path=module_path,
-                prefix=f"{module_importname}.",
-            )
-        ])
+        module_names.extend(
+            [
+                mod_info.name
+                for mod_info in pkgutil.walk_packages(
+                    path=module_path,
+                    prefix=f"{module_importname}.",
+                )
+            ]
+        )
         if not include_private:
             module_names = [
-                name for name in module_names
-                if not any(part.startswith("_") for part in name.split(".")[1:])
-           ]
+                name
+                for name in module_names
+                if not any(
+                    part.startswith("_") for part in name.split(".")[1:]
+                )
+            ]
 
     return module_names
 

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -1,26 +1,31 @@
 #!/usr/bin/env python3
+"""CLI runner interface for Python doctests.
+
+TODO this utility should be templated for easy code sharing across repos.
+"""
+
 import argparse
 import doctest
 import importlib
-import os
 from pathlib import Path
 import pkgutil
 import sys
 import traceback
+from typing import Any, Callable
 import warnings
 
 
 def list_modules_recursive(
     module_importname: str,
     include_private: bool = True,
-    exclude_matches: list[str] = [],
-):
+    exclude_fragments: list[str] = [],
+) -> list[str]:
     """Find all the submodules of a given module.
 
     Also filter with private and exclude controls.
     """
     module_names = [module_importname]
-    # Identify module from its import path (no import -> fail back to caller)
+    # Identify module from its import path : N.B. fail --> return [module-path]
     try:
         error = None
         module = importlib.import_module(module_importname)
@@ -29,118 +34,104 @@ def list_modules_recursive(
         error = exc
 
     if error is None:
-        # Add sub-modules to the list
+        # Add all sub-modules to the list
         # Get the filepath of the module base directory
-        module_filepath = Path(module.__file__)
+        module_filepath = Path(str(module.__file__))
         if module_filepath.name == "__init__.py":
-            search_filepath = str(module_filepath.parent)
-            for _, name, ispkg in pkgutil.iter_modules([search_filepath]):
-                if name.startswith("_") and not include_private:
+            for _, name, ispkg in pkgutil.iter_modules([module_filepath.parent]):
+                if name[:1] == "_" and not include_private:
                     continue
-
                 submodule_name = module_importname + "." + name
-                if any(match in submodule_name for match in exclude_matches):
+                if any(match in submodule_name for match in exclude_fragments):
                     continue
-
                 module_names.append(submodule_name)
                 if ispkg:
                     module_names.extend(
                         list_modules_recursive(
                             submodule_name,
                             include_private=include_private,
-                            exclude_matches=exclude_matches,
+                            exclude_fragments=exclude_fragments,
                         )
                     )
 
-    # I don't know why there are duplicates, but there can be.
-    result = []
-    for name in module_names:
-        if name not in result:
-            # For some reason, some things get listed twice.
-            result.append(name)
-
-    return result
+    # Remove duplicates, which may occur.
+    return sorted(set(module_names))
 
 
 def list_filepaths_recursive(
-    file_path: str, exclude_matches: list[str] = []
+    file_spec: str, exclude_fragments: list[str] = []
 ) -> list[Path]:
-    """Expand globs to a list of filepaths.
+    """Expand a filepath string, possibly containing globs, to a list of filepaths.
 
     Also filter with exclude controls.
     """
-    actual_paths: list[Path] = []
-    segments = file_path.split("/")
+    segments = file_spec.split("/")
     i_wilds = [
         index
         for index, segment in enumerate(segments)
         if any(char in segment for char in "*?[")
     ]
     if len(i_wilds) == 0:
-        actual_paths.append(Path(file_path))
+        found_paths = [Path(file_spec)]
     else:
         i_first_wild = i_wilds[0]
+        # Split into a regular path prefix + the part including globs
         base_path = Path("/".join(segments[:i_first_wild]))
-        file_spec = "/".join(segments[i_first_wild:])
-        # This is the magic bit! expand with globs, '**' enabling recursive
-        actual_paths += list(base_path.glob(file_spec))
+        glob_spec = "/".join(segments[i_first_wild:])
+        # expand with globs
+        found_paths = list(base_path.glob(glob_spec))
 
-    # Also apply exclude and private filters to results
-    result = [
+    # Also apply excludes to results
+    # NB there is NO "private" filtering for sourcefiles
+    found_paths = [
         path
-        for path in actual_paths
-        if not any(match in str(path) for match in exclude_matches)
-        and not path.name.startswith("_")
+        for path in found_paths
+        if not path.is_dir()
+        and not any(match in str(path) for match in exclude_fragments)
     ]
-    return result
+    return found_paths
 
 
 def process_options(
     opt_str: str, paths_are_modules: bool = True
-) -> dict[str, str]:
+) -> dict[str, str | int | bool]:
     """Convert the "-o/--options" arg into a **kwargs for the doctest function call."""
-    # Remove all spaces (think they are never needed).
-    opt_str = opt_str.replace(" ", "")
+    opt_str = opt_str.replace(" ", "")  # Remove spaces -- never meaningful
     # Split on commas, and split each one on "=" expecting a simple name=val form
-    opts_dict = {}
+    opts_dict: dict[str, str | int | bool] = {}
     if opt_str:  # N.B. to avoid unexpected behaviour: "".split() --> [""]
         for setting_str in opt_str.split(","):
             try:
                 name, val = setting_str.split("=")
-
-                # Detect + translate numeric and boolean values.
+                # Detect + translate integers and booleans (only, else leave as 'str').
+                value: str | int | bool = val
                 bool_vals = {"true": True, "false": False}
                 if val.isdigit():
-                    val = int(val)
+                    value = int(val)
                 elif val.lower() in bool_vals:
-                    val = bool_vals[val.lower()]
-
+                    value = bool_vals[val.lower()]
             except ValueError:
                 msg = f"Invalid option setting {setting_str!r}, expected 'name=value' only."
                 raise ValueError(msg)
+            opts_dict[name] = value
 
-            opts_dict[name] = val
-
-    # Post-process to "fix" options, especially to correct defaults
-    # TODO this is not very clever, think of something better??
+    # Implement some handy defaults
     if not paths_are_modules:
         if not "module_relative" in opts_dict:
-            opts_dict["module_relative"] = False
-    if not "verbose" in opts_dict:
-        opts_dict["verbose"] = False
+            opts_dict["module_relative"] = False  # we want this OFF, by default anyway
     if not "optionflags" in opts_dict:
         default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
-        opts_dict["optionflags"] = default_flags
+        opts_dict["optionflags"] = default_flags  # a generally useful default?
 
     return opts_dict
 
 
 def run_doctest_paths(
-    paths: list[str],
+    paths: list[str] | list[Path],
     paths_are_modules: bool = False,
     recurse_modules: bool = False,
     include_private_modules: bool = False,
-    exclude_matches: list[str] = [],
+    exclude_fragments: list[str] = [],
     doctest_kwargs: dict = {},
     verbose: bool = False,
     dry_run: bool = False,
@@ -155,7 +146,7 @@ def run_doctest_paths(
             f", paths_are_modules={paths_are_modules!r}"
             f", recurse_modules={recurse_modules!r}"
             f", include_private_modules={include_private_modules!r}"
-            f", exclude_matches={exclude_matches!r}"
+            f", exclude_fragments={exclude_fragments!r}"
             f", doctest_kwargs={doctest_kwargs!r}"
             f", verbose={verbose!r}"
             f", dry_run={dry_run!r}"
@@ -169,15 +160,16 @@ def run_doctest_paths(
     # For now at least, simply discard ALL warnings.
     warnings.simplefilter("ignore")
 
+    doctest_function: Callable
     if paths_are_modules:
         doctest_function = doctest.testmod
         if recurse_modules:
             module_paths = []
             for path in paths:
                 module_paths += list_modules_recursive(
-                    path,
+                    str(path),  # for modules, 'paths' are always strings anyway
                     include_private=include_private_modules,
-                    exclude_matches=exclude_matches,
+                    exclude_fragments=exclude_fragments,
                 )
             paths = module_paths
     else:
@@ -186,7 +178,7 @@ def run_doctest_paths(
         filepaths = []
         for path in paths:
             filepaths += list_filepaths_recursive(
-                path, exclude_matches=exclude_matches
+                str(path), exclude_fragments=exclude_fragments
             )
         paths = filepaths
 
@@ -197,9 +189,11 @@ def run_doctest_paths(
             continue
 
         op_fail = None
+        arg: Any  # can be a string or a 'Module' object
         if paths_are_modules:
+            path_str = str(path)
             try:
-                arg = importlib.import_module(path)
+                arg = importlib.import_module(path_str)
             except Exception as exc:
                 op_fail = exc
         else:
@@ -318,10 +312,7 @@ _parser.add_argument(
     default="",
 )
 _parser.add_argument(
-    "-v",
-    "--verbose",
-    action="store_true",
-    help="show details of each operation.",
+    "-v", "--verbose", action="store_true", help="show details of each operation."
 )
 _parser.add_argument(
     "-d",
@@ -350,7 +341,7 @@ def parserargs_as_kwargs(args):
         paths_are_modules=args.module,
         recurse_modules=args.recurse,
         include_private_modules=not args.publiconly,
-        exclude_matches=args.exclude or [],
+        exclude_fragments=args.exclude or [],
         doctest_kwargs=process_options(args.options, args.module),
         verbose=args.verbose,
         dry_run=args.dryrun,

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -34,9 +34,13 @@ def list_modules_recursive(
 
     if error is None:
         # Add all sub-modules to the list
-        module_filepath = Path(str(module.__file__))  # Get filepath of module base
+        module_filepath = Path(
+            str(module.__file__)
+        )  # Get filepath of module base
         if module_filepath.name == "__init__.py":
-            for _, name, ispkg in pkgutil.iter_modules([module_filepath.parent]):
+            for _, name, ispkg in pkgutil.iter_modules(
+                [module_filepath.parent]
+            ):
                 if name[:1] == "_" and not include_private:
                     continue
                 submodule_name = module_importname + "." + name
@@ -65,17 +69,15 @@ def list_filepaths_recursive(
         found_paths = [Path(file_spec)]
     else:
         # split the path and do a glob --> list[Path]
-        path = Path(file_spec).absolute()  # make absolute so we can get a root part
+        path = Path(
+            file_spec
+        ).absolute()  # make absolute so we can get a root part
         base_pth = Path(path.root)
         glob_path = path.relative_to(base_pth)
         found_paths = base_pth.glob(glob_path)
 
     # Apply excludes to results : NB no "private" option (unlike modules)
-    found_paths = [
-        path
-        for path in found_paths
-        if not path.is_dir()
-    ]
+    found_paths = [path for path in found_paths if not path.is_dir()]
     return found_paths
 
 
@@ -105,7 +107,9 @@ def process_options(
     # Implement some handy defaults
     if not paths_are_modules:
         if not "module_relative" in opts_dict:
-            opts_dict["module_relative"] = False  # we want this OFF, by default anyway
+            opts_dict["module_relative"] = (
+                False  # we want this OFF, by default anyway
+            )
     if not "optionflags" in opts_dict:
         default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
         opts_dict["optionflags"] = default_flags  # a generally useful default?
@@ -154,7 +158,9 @@ def run_doctest_paths(
             module_paths = []
             for path in paths:
                 module_paths += list_modules_recursive(
-                    str(path),  # for modules, 'paths' are always strings anyway
+                    str(
+                        path
+                    ),  # for modules, 'paths' are always strings anyway
                     include_private=include_private_modules,
                     # exclude_fragments=exclude_fragments,
                 )
@@ -165,7 +171,7 @@ def run_doctest_paths(
         filepaths = []
         for path in paths:
             filepaths += list_filepaths_recursive(
-                str(path) #, exclude_fragments=exclude_fragments
+                str(path)  # , exclude_fragments=exclude_fragments
             )
         paths = filepaths
 
@@ -302,7 +308,10 @@ _parser.add_argument(
     default="",
 )
 _parser.add_argument(
-    "-v", "--verbose", action="store_true", help="show details of each operation."
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="show details of each operation.",
 )
 _parser.add_argument(
     "-d",

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -3,16 +3,17 @@ import argparse
 import doctest
 import importlib
 import os
-import traceback
 from pathlib import Path
 import pkgutil
 import sys
+import traceback
 import warnings
 
 
 def list_modules_recursive(
-    module_importname: str, include_private: bool = True,
-    exclude_matches: list[str] = []
+    module_importname: str,
+    include_private: bool = True,
+    exclude_matches: list[str] = [],
 ):
     """Find all the submodules of a given module.
 
@@ -45,7 +46,8 @@ def list_modules_recursive(
                 if ispkg:
                     module_names.extend(
                         list_modules_recursive(
-                            submodule_name, include_private=include_private,
+                            submodule_name,
+                            include_private=include_private,
                             exclude_matches=exclude_matches,
                         )
                     )
@@ -61,8 +63,7 @@ def list_modules_recursive(
 
 
 def list_filepaths_recursive(
-    file_path: str,
-    exclude_matches: list[str] = []
+    file_path: str, exclude_matches: list[str] = []
 ) -> list[Path]:
     """Expand globs to a list of filepaths.
 
@@ -71,7 +72,8 @@ def list_filepaths_recursive(
     actual_paths: list[Path] = []
     segments = file_path.split("/")
     i_wilds = [
-        index for index, segment in enumerate(segments)
+        index
+        for index, segment in enumerate(segments)
         if any(char in segment for char in "*?[")
     ]
     if len(i_wilds) == 0:
@@ -85,7 +87,8 @@ def list_filepaths_recursive(
 
     # Also apply exclude and private filters to results
     result = [
-        path for path in actual_paths
+        path
+        for path in actual_paths
         if not any(match in str(path) for match in exclude_matches)
         and not path.name.startswith("_")
     ]
@@ -132,7 +135,7 @@ def process_options(opt_str: str, paths_are_modules: bool = True) -> dict[str, s
 
 def run_doctest_paths(
     paths: list[str],
-    paths_are_modules:bool = False,
+    paths_are_modules: bool = False,
     recurse_modules: bool = False,
     include_private_modules: bool = False,
     exclude_matches: list[str] = [],
@@ -170,8 +173,9 @@ def run_doctest_paths(
             module_paths = []
             for path in paths:
                 module_paths += list_modules_recursive(
-                    path, include_private=include_private_modules,
-                    exclude_matches=exclude_matches
+                    path,
+                    include_private=include_private_modules,
+                    exclude_matches=exclude_matches,
                 )
             paths = module_paths
     else:
@@ -179,15 +183,12 @@ def run_doctest_paths(
         doctest_function = doctest.testfile
         filepaths = []
         for path in paths:
-            filepaths += list_filepaths_recursive(
-                path,
-                exclude_matches=exclude_matches
-            )
+            filepaths += list_filepaths_recursive(path, exclude_matches=exclude_matches)
         paths = filepaths
 
     for path in paths:
         if verbose:
-            print(f"\n-----\ndoctest.{doctest_function.__name__}: {path!r}")
+            print(f"\n-----\ndoctest.{doctest_function.__name__}: {path}")
         if dry_run:
             continue
 
@@ -207,7 +208,14 @@ def run_doctest_paths(
                 n_total_tests += n_tests
                 n_paths_tested += 1
                 if n_fails:
-                    print(f"\nERRORS in path: {arg}\n")
+                    n_ok = n_tests - n_fails
+                    msg = (
+                        f"**ERRORS**\n"
+                        f"{n_ok}/{n_tests} OK, {n_fails}/{n_tests} FAILED in path: {path}"
+                    )
+                    print(msg)
+                elif verbose:
+                    print(f"{n_tests}/{n_tests} OK in path: {path}")
             except Exception as exc:
                 op_fail = exc
 
@@ -235,14 +243,14 @@ def run_doctest_paths(
             f"    paths tested    = {n_paths_tested}",
             f"    tests completed = {n_total_tests}",
             f"    errors          = {n_total_fails}",
-            ""
+            "",
         ]
         if n_total_fails > 0:
             msgs += ["FAILED."]
         else:
             msgs += ["OK."]
 
-        print('\n'.join(msgs))
+        print("\n".join(msgs))
 
     return n_total_fails
 
@@ -272,8 +280,10 @@ _parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
 )
 _parser.add_argument(
-    "-m", "--module", action="store_true",
-    help="paths are module paths (xx.yy.zz), instead of filepaths."
+    "-m",
+    "--module",
+    action="store_true",
+    help="paths are module paths (xx.yy.zz), instead of filepaths.",
 )
 _parser.add_argument(
     "-r",
@@ -298,8 +308,7 @@ _parser.add_argument(
     "--options",
     nargs="?",
     help=(
-        "kwargs (Python) for doctest call"
-        ", e.g. \"raise_on_error=True,optionflags=8\"."
+        'kwargs (Python) for doctest call, e.g. "raise_on_error=True,optionflags=8".'
     ),
     type=str,
     default="",

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -23,38 +23,31 @@ def list_modules_recursive(
 
     Also filter out private modules, if selected.
     """
-    module_names = [module_importname]
+
     # Identify module from its import path : N.B. fail --> return [module-path]
+    module_names = [module_importname]
+    module_path = None
     try:
-        error = None
         module = importlib.import_module(module_importname)
+        module_path = getattr(module, "__path__", None)
     except Exception as exc:
-        print(f"\n\nIMPORT FAILED: {module_importname}\n")
-        error = exc
+        print(f"\n\nIMPORT FAILED: {module_importname}\n  error: {exc}")
 
-    if error is None:
-        # Add all sub-modules to the list
-        module_filepath = Path(
-            str(module.__file__)
-        )  # Get filepath of module base
-        if module_filepath.name == "__init__.py":
-            for _, name, ispkg in pkgutil.iter_modules(
-                [module_filepath.parent]
-            ):
-                if name[:1] == "_" and not include_private:
-                    continue
-                submodule_name = module_importname + "." + name
-                module_names.append(submodule_name)
-                if ispkg:
-                    module_names.extend(
-                        list_modules_recursive(
-                            submodule_name,
-                            include_private=include_private,
-                        )
-                    )
+    if module_path is not None:
+        module_names.extend([
+            mod_info.name
+            for mod_info in pkgutil.walk_packages(
+                path=module_path,
+                prefix=f"{module_importname}.",
+            )
+        ])
+        if not include_private:
+            module_names = [
+                name for name in module_names
+                if not any(part.startswith("_") for part in name.split(".")[1:])
+           ]
 
-    # Remove duplicates, which may occur.
-    return sorted(set(module_names))
+    return module_names
 
 
 def list_filepaths_recursive(
@@ -65,20 +58,18 @@ def list_filepaths_recursive(
     Also filter with exclude controls.
     """
     if not any(c in file_spec for c in "?*["):
-        # when no globs, action the (single) filepath --> error if it doesn't exist
         found_paths = [Path(file_spec)]
     else:
-        # split the path and do a glob --> list[Path]
-        path = Path(
-            file_spec
-        ).absolute()  # make absolute so we can get a root part
-        base_pth = Path(path.root)
-        glob_path = path.relative_to(base_pth)
-        found_paths = base_pth.glob(glob_path)
+        path = Path(file_spec).expanduser()
+        if path.is_absolute():
+            glob_root = Path(path.anchor)
+            glob_pattern = path.relative_to(glob_root)
+        else:
+            glob_root = Path.cwd()
+            glob_pattern = path
+        found_paths = list(glob_root.glob(str(glob_pattern)))
 
-    # Apply excludes to results : NB no "private" option (unlike modules)
-    found_paths = [path for path in found_paths if not path.is_dir()]
-    return found_paths
+    return [path for path in found_paths if not path.is_dir()]
 
 
 def process_options(

--- a/tools/test_run_doctests.py
+++ b/tools/test_run_doctests.py
@@ -116,37 +116,6 @@ class TestListModules:
             "tmp_test_module.sm2.s6",
         ]
 
-    def test_exclude_submod(self, tempmodules):
-        result = list_modules_recursive(tempmodules, exclude_fragments=["sm1"])
-        assert result == [
-            "tmp_test_module",
-            "tmp_test_module.s0",
-            "tmp_test_module.s1",
-            "tmp_test_module.sm2",
-            "tmp_test_module.sm2.s6",
-        ]
-
-    def test_exclude_namematch(self, tempmodules):
-        result = list_modules_recursive(tempmodules, exclude_fragments=["s1"])
-        assert result == [
-            "tmp_test_module",
-            "tmp_test_module.s0",
-            # 'tmp_test_module.s1',
-            "tmp_test_module.sm1",
-            # 'tmp_test_module.sm1._ps1',
-            # 'tmp_test_module.sm1.s1',
-            "tmp_test_module.sm1.s2",
-            "tmp_test_module.sm1.ssm1",
-            "tmp_test_module.sm1.ssm1.s3",
-            "tmp_test_module.sm1.ssm1.s4",
-            "tmp_test_module.sm1.ssm2",
-            "tmp_test_module.sm1.ssm2._ps2",
-            "tmp_test_module.sm1.ssm2.s4",
-            "tmp_test_module.sm1.ssm2.s5",
-            "tmp_test_module.sm2",
-            "tmp_test_module.sm2.s6",
-        ]
-
 
 class TestListSources:
     def test_nonexist(self, tempsources):
@@ -194,24 +163,6 @@ class TestListSources:
                 "maindir/subdir1/subsubdir2/s4.rst",
                 "maindir/subdir1/subsubdir2/s5.rst",
                 "maindir/subdir1/subsubdir2/_px2.rst",
-            ]
-        ]
-
-    def test_recurse_exclude_subpath(self, tempsources, tmp_path):
-        result = list_filepaths_recursive(
-            tempsources + "/**/*.rst", exclude_fragments=["/subsubdir2/"]
-        )
-        assert result == [
-            tmp_path / pathstr
-            for pathstr in [
-                "maindir/s0.rst",
-                "maindir/s1.rst",
-                "maindir/subdir1/s1.rst",
-                "maindir/subdir1/s2.rst",
-                "maindir/subdir1/_px1.rst",
-                "maindir/subdir2/s6.rst",
-                "maindir/subdir1/subsubdir1/s3.rst",  # Note the odd ordering
-                "maindir/subdir1/subsubdir1/s4.rst",
             ]
         ]
 
@@ -441,3 +392,37 @@ class TestCliModules:
             assert n_mods > 1
         else:
             assert n_mods == 1
+
+    @pytest.mark.parametrize("exclude", ["noexclude", "exclude"])
+    def test_realrun_submodules(self, exclude):
+        # Tested via CLI because the exclude logic is now common to modules+sourcefiles
+        do_exclude = exclude == "exclude"
+        args = ["-mrd", "curses"]
+        if do_exclude:
+            args += ["-e", "as"]
+        result = runmain(*args)
+        expected = [
+            '-----',
+            'doctest.testmod: curses',
+        ]
+        if not do_exclude:
+            expected += [
+                '-----',
+                'doctest.testmod: curses.ascii',
+                '-----',
+                'doctest.testmod: curses.has_key',
+            ]
+        expected += [
+            '-----',
+            'doctest.testmod: curses.panel',
+            '-----',
+            'doctest.testmod: curses.textpad',
+            '=====',
+            'run_doctest: FINAL REPORT',
+            '(DRY RUN: no actual tests)',
+            '    paths tested    = 0',
+            '    tests completed = 0',
+            '    errors          = 0',
+            'OK.'
+        ]
+        assert result == expected

--- a/tools/test_run_doctests.py
+++ b/tools/test_run_doctests.py
@@ -284,7 +284,10 @@ class TestCliSources:
         result = runmain(badsources + "/*.*t", "-vf", expect_rc=1)
         result_fullstr = "\n".join(result)
         assert not "s1.rst" in result_fullstr
-        assert f"0/1 OK, 1/1 FAILED in path: {badsources}/s0.rst" in result_fullstr
+        assert (
+            f"0/1 OK, 1/1 FAILED in path: {badsources}/s0.rst"
+            in result_fullstr
+        )
         test_lines = [
             "(FAIL FAST: stopped at first path with errors)",
             "    paths tested    = 1",
@@ -368,7 +371,10 @@ class TestCliModules:
     @pytest.mark.parametrize("publiconly", [False, True])
     def test_modules_publiconly(self, publiconly):
         """Check that the '-p' option is passed down."""
-        args = ["argparse", "-mdv"]  # NB list module: don't recurse or run actual tests
+        args = [
+            "argparse",
+            "-mdv",
+        ]  # NB list module: don't recurse or run actual tests
         if publiconly:
             args += ["-p"]
         result = runmain(*args)
@@ -402,27 +408,27 @@ class TestCliModules:
             args += ["-e", "as"]
         result = runmain(*args)
         expected = [
-            '-----',
-            'doctest.testmod: curses',
+            "-----",
+            "doctest.testmod: curses",
         ]
         if not do_exclude:
             expected += [
-                '-----',
-                'doctest.testmod: curses.ascii',
-                '-----',
-                'doctest.testmod: curses.has_key',
+                "-----",
+                "doctest.testmod: curses.ascii",
+                "-----",
+                "doctest.testmod: curses.has_key",
             ]
         expected += [
-            '-----',
-            'doctest.testmod: curses.panel',
-            '-----',
-            'doctest.testmod: curses.textpad',
-            '=====',
-            'run_doctest: FINAL REPORT',
-            '(DRY RUN: no actual tests)',
-            '    paths tested    = 0',
-            '    tests completed = 0',
-            '    errors          = 0',
-            'OK.'
+            "-----",
+            "doctest.testmod: curses.panel",
+            "-----",
+            "doctest.testmod: curses.textpad",
+            "=====",
+            "run_doctest: FINAL REPORT",
+            "(DRY RUN: no actual tests)",
+            "    paths tested    = 0",
+            "    tests completed = 0",
+            "    errors          = 0",
+            "OK.",
         ]
         assert result == expected

--- a/tools/test_run_doctests.py
+++ b/tools/test_run_doctests.py
@@ -1,0 +1,443 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import pytest
+import run_doctests
+from run_doctests import list_filepaths_recursive, list_modules_recursive
+
+
+def make_dirs_and_files(pattern, basepath):
+    for dirname, pyfiles in pattern.items():
+        dirpath = basepath / dirname.replace(".", "/")
+        if not dirpath.exists():
+            dirpath.mkdir()
+        for content in pyfiles:
+            with open(dirpath / content, "w") as mainfile:
+                # Just create an empty top-level file
+                pass
+
+
+@pytest.fixture
+def tempmodules(tmp_path):
+    """Create  temporary discoverable modules."""
+    basename = "tmp_test_module"
+    patt = {
+        basename: ["__init__.py", "s0.py", "s1.py"],
+        basename + ".sm1": ["__init__.py", "s1.py", "s2.py", "_ps1.py"],
+        basename + ".sm1.ssm1": ["__init__.py", "s3.py", "s4.py"],
+        basename + ".sm1.ssm2": ["__init__.py", "s4.py", "s5.py", "_ps2.py"],
+        basename + ".notamodule": ["xx1.py", "xx2.py"],
+        basename + ".sm2": ["__init__.py", "s6.py"],
+    }
+    make_dirs_and_files(patt, tmp_path)
+    try:
+        sys.path.append(str(tmp_path))
+        yield "tmp_test_module"
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+@pytest.fixture
+def tempsources(tmp_path):
+    """Create temporary sourcefiles."""
+    patt = {
+        "maindir": ["s0.rst", "s1.rst", "ignore.this"],
+        "maindir/subdir1": ["s1.rst", "s2.rst", "_px1.rst"],
+        "maindir/subdir1/subsubdir1": ["s3.rst", "s4.rst"],
+        "maindir/subdir1/subsubdir2": ["s4.rst", "s5.rst", "_px2.rst"],
+        "maindir/subdir2": ["s6.rst"],
+    }
+    make_dirs_and_files(patt, tmp_path)
+    return str(tmp_path / "maindir")  # targets must be str, not Path
+
+
+@pytest.fixture
+def badsources(tempsources):
+    # Same as tempsources, but put a failing doctest in the first source file
+    filepath = Path(tempsources) / "s0.rst"
+    with open(filepath, "wt") as f_out:
+        f_out.write(">>> 1\n0\n")
+    return tempsources
+
+
+class TestListModules:
+    def test_import(self, tempmodules):
+        """Check that 'tempmodules' puts the test module on the import path."""
+        import tmp_test_module
+
+        assert "<module 'tmp_test_module' from" in str(tmp_test_module)
+
+    def test_nomatch(self):
+        result = list_modules_recursive("not.exists")
+        assert result == ["not.exists"]
+
+    def test_recurse(self, tempmodules):
+        result = list_modules_recursive(tempmodules)
+        assert result == [
+            "tmp_test_module",
+            "tmp_test_module.s0",
+            "tmp_test_module.s1",
+            "tmp_test_module.sm1",
+            "tmp_test_module.sm1._ps1",
+            "tmp_test_module.sm1.s1",
+            "tmp_test_module.sm1.s2",
+            "tmp_test_module.sm1.ssm1",
+            "tmp_test_module.sm1.ssm1.s3",
+            "tmp_test_module.sm1.ssm1.s4",
+            "tmp_test_module.sm1.ssm2",
+            "tmp_test_module.sm1.ssm2._ps2",
+            "tmp_test_module.sm1.ssm2.s4",
+            "tmp_test_module.sm1.ssm2.s5",
+            "tmp_test_module.sm2",
+            "tmp_test_module.sm2.s6",
+        ]
+
+    def test_recurse_noprivate(self, tempmodules):
+        result = list_modules_recursive(tempmodules, include_private=False)
+        assert result == [
+            "tmp_test_module",
+            "tmp_test_module.s0",
+            "tmp_test_module.s1",
+            "tmp_test_module.sm1",
+            # 'tmp_test_module.sm1._ps1',
+            "tmp_test_module.sm1.s1",
+            "tmp_test_module.sm1.s2",
+            "tmp_test_module.sm1.ssm1",
+            "tmp_test_module.sm1.ssm1.s3",
+            "tmp_test_module.sm1.ssm1.s4",
+            "tmp_test_module.sm1.ssm2",
+            # 'tmp_test_module.sm1.ssm2._ps2',
+            "tmp_test_module.sm1.ssm2.s4",
+            "tmp_test_module.sm1.ssm2.s5",
+            "tmp_test_module.sm2",
+            "tmp_test_module.sm2.s6",
+        ]
+
+    def test_exclude_submod(self, tempmodules):
+        result = list_modules_recursive(tempmodules, exclude_fragments=["sm1"])
+        assert result == [
+            "tmp_test_module",
+            "tmp_test_module.s0",
+            "tmp_test_module.s1",
+            "tmp_test_module.sm2",
+            "tmp_test_module.sm2.s6",
+        ]
+
+    def test_exclude_namematch(self, tempmodules):
+        result = list_modules_recursive(tempmodules, exclude_fragments=["s1"])
+        assert result == [
+            "tmp_test_module",
+            "tmp_test_module.s0",
+            # 'tmp_test_module.s1',
+            "tmp_test_module.sm1",
+            # 'tmp_test_module.sm1._ps1',
+            # 'tmp_test_module.sm1.s1',
+            "tmp_test_module.sm1.s2",
+            "tmp_test_module.sm1.ssm1",
+            "tmp_test_module.sm1.ssm1.s3",
+            "tmp_test_module.sm1.ssm1.s4",
+            "tmp_test_module.sm1.ssm2",
+            "tmp_test_module.sm1.ssm2._ps2",
+            "tmp_test_module.sm1.ssm2.s4",
+            "tmp_test_module.sm1.ssm2.s5",
+            "tmp_test_module.sm2",
+            "tmp_test_module.sm2.s6",
+        ]
+
+
+class TestListSources:
+    def test_nonexist(self, tempsources):
+        result = list_filepaths_recursive("none")
+        assert result == [Path("none")]
+
+    def test_toponly(self, tempsources, tmp_path):
+        result = list_filepaths_recursive(tempsources)
+        assert result == []
+
+    def test_recurse_all(self, tempsources, tmp_path):
+        result = list_filepaths_recursive(tempsources + "/**/*")
+        assert result == [
+            tmp_path / pathstr
+            for pathstr in [
+                "maindir/s0.rst",
+                "maindir/s1.rst",
+                "maindir/ignore.this",
+                "maindir/subdir1/s1.rst",
+                "maindir/subdir1/s2.rst",
+                "maindir/subdir1/_px1.rst",
+                "maindir/subdir2/s6.rst",
+                "maindir/subdir1/subsubdir1/s3.rst",
+                "maindir/subdir1/subsubdir1/s4.rst",
+                "maindir/subdir1/subsubdir2/s4.rst",
+                "maindir/subdir1/subsubdir2/s5.rst",
+                "maindir/subdir1/subsubdir2/_px2.rst",
+            ]
+        ]
+
+    def test_recurse_rsts(self, tempsources, tmp_path):
+        result = list_filepaths_recursive(tempsources + "/**/*.rst")
+        assert result == [
+            tmp_path / pathstr
+            for pathstr in [
+                "maindir/s0.rst",
+                "maindir/s1.rst",
+                # 'maindir/ignore.this',
+                "maindir/subdir1/s1.rst",
+                "maindir/subdir1/s2.rst",
+                "maindir/subdir1/_px1.rst",
+                "maindir/subdir2/s6.rst",
+                "maindir/subdir1/subsubdir1/s3.rst",
+                "maindir/subdir1/subsubdir1/s4.rst",
+                "maindir/subdir1/subsubdir2/s4.rst",
+                "maindir/subdir1/subsubdir2/s5.rst",
+                "maindir/subdir1/subsubdir2/_px2.rst",
+            ]
+        ]
+
+    def test_recurse_exclude_subpath(self, tempsources, tmp_path):
+        result = list_filepaths_recursive(
+            tempsources + "/**/*.rst", exclude_fragments=["/subsubdir2/"]
+        )
+        assert result == [
+            tmp_path / pathstr
+            for pathstr in [
+                "maindir/s0.rst",
+                "maindir/s1.rst",
+                "maindir/subdir1/s1.rst",
+                "maindir/subdir1/s2.rst",
+                "maindir/subdir1/_px1.rst",
+                "maindir/subdir2/s6.rst",
+                "maindir/subdir1/subsubdir1/s3.rst",  # Note the odd ordering
+                "maindir/subdir1/subsubdir1/s4.rst",
+            ]
+        ]
+
+    def test_recurse_namematch_1(self, tempsources, tmp_path):
+        """Search for '*s*.rst'."""
+        result = list_filepaths_recursive(
+            tempsources + "/**/*s*.rst",
+        )
+        assert result == [
+            tmp_path / pathstr
+            for pathstr in [
+                "maindir/s0.rst",
+                "maindir/s1.rst",
+                "maindir/subdir1/s1.rst",
+                "maindir/subdir1/s2.rst",
+                "maindir/subdir2/s6.rst",
+                "maindir/subdir1/subsubdir1/s3.rst",
+                "maindir/subdir1/subsubdir1/s4.rst",
+                "maindir/subdir1/subsubdir2/s4.rst",
+                "maindir/subdir1/subsubdir2/s5.rst",
+            ]
+        ]
+
+    def test_recurse_namematch_2(self, tempsources, tmp_path):
+        """Search for '*1.rst'."""
+        result = list_filepaths_recursive(
+            tempsources + "/**/*1.rst",
+        )
+        assert result == [
+            tmp_path / pathstr
+            for pathstr in [
+                "maindir/s1.rst",
+                "maindir/subdir1/s1.rst",
+                "maindir/subdir1/_px1.rst",
+            ]
+        ]
+
+    def test_recurse_match_nonexist_glob(self, tempsources, tmp_path):
+        result = list_filepaths_recursive(tempsources + "/*pqr*")
+        assert result == []
+
+    def test_recurse_match_nonexist_noglob(self, tempsources, tmp_path):
+        search_path = tempsources + "subdir1/non.exist"
+        # As not actually a search, returns the given path.
+        result = list_filepaths_recursive(search_path)
+        assert result == [Path(search_path)]
+
+
+_env_path = (Path(os.__file__) / "../../../bin/python").resolve()
+assert _env_path.exists()
+_PYTHON_PATHSTR = str(_env_path)
+
+_doctests_path = Path(run_doctests.__file__).resolve()
+_DOCTESTS_PATH = str(_doctests_path)
+
+_RE_ANY_NONBLANK = re.compile(r".*\S.*")
+
+
+def runmain(*args, expect_rc: int | None = 0) -> list[str]:
+    arglist = [_PYTHON_PATHSTR, _DOCTESTS_PATH] + list(args)
+    call_data = subprocess.run(arglist, capture_output=True)
+    rc = call_data.returncode
+    if expect_rc is not None:
+        assert rc == expect_rc
+    lines = call_data.stdout.decode("ascii").split("\n")
+    # for simplicity, remove blank lines.
+    lines = [line for line in lines if _RE_ANY_NONBLANK.match(line)]
+    return lines
+
+
+class TestCliSources:
+    def test_nopaths_help(self, tempsources):
+        result = runmain()
+        # Choose some sample lines to show it has output help text.
+        test_lines = [
+            "Run doctests in docs files, or docstrings in packages.",
+            "Notes:",
+            "* N.B. use ** to include subdirectories",
+        ]
+        for test_line in test_lines:
+            assert test_line in [line.strip() for line in result]
+
+    def test_multipath(self, tempsources):
+        result = runmain("this", "that", "other", "--dryrun")
+        assert result == [
+            "-----",
+            "doctest.testfile: this",
+            "-----",
+            "doctest.testfile: that",
+            "-----",
+            "doctest.testfile: other",
+            "=====",
+            "run_doctest: FINAL REPORT",
+            "(DRY RUN: no actual tests)",
+            "    paths tested    = 0",
+            "    tests completed = 0",
+            "    errors          = 0",
+            "OK.",
+        ]
+
+    def test_basic_error(self, badsources):
+        result = runmain(badsources + "/*.rst", "-v", expect_rc=1)
+        test_lines = f"""
+            paths_are_modules=False, recurse_modules=False, include_private_modules=True, exclude_fragments=[], doctest_kwargs={{'module_relative': False, 'optionflags': 12}}, verbose=True, dry_run=False, stop_on_failure=False
+            0/1 OK, 1/1 FAILED in path: {badsources}/s0.rst
+            0/0 OK in path: {badsources}/s1.rst
+            run_doctest: FINAL REPORT
+                paths tested    = 2
+                tests completed = 1
+                errors          = 1
+
+            FAILED.
+        """
+        result = "\n".join(result)
+        for line in test_lines.split("\n"):
+            assert line.strip() in result
+
+    def test_stop_on_fail(self, badsources):
+        result = runmain(badsources + "/*.*t", "-vf", expect_rc=1)
+        result_fullstr = "\n".join(result)
+        assert not "s1.rst" in result_fullstr
+        assert f"0/1 OK, 1/1 FAILED in path: {badsources}/s0.rst" in result_fullstr
+        test_lines = [
+            "(FAIL FAST: stopped at first path with errors)",
+            "    paths tested    = 1",
+            "    tests completed = 1",
+            "    errors          = 1",
+            "FAILED.",
+        ]
+        assert result[-5:] == test_lines
+
+    def test_options_passing(self):
+        result = runmain(
+            "any/*.rst",
+            "--dryrun",
+            "--verbose",
+            "-o",
+            "module_relative=false, junk= 3, unknown=this",
+        )
+        expected = [
+            "RUNNING run_doctest(paths=['any/*.rst'], paths_are_modules=False, "
+            "recurse_modules=False, include_private_modules=True, exclude_fragments=[], "
+            "doctest_kwargs={'module_relative': False, 'junk': 3, 'unknown': 'this', "
+            "'optionflags': 12}, verbose=True, dry_run=True, stop_on_failure=False)",
+            "=====",
+            "run_doctest: FINAL REPORT",
+            "(DRY RUN: no actual tests)",
+            "    paths tested    = 0",
+            "    tests completed = 0",
+            "    errors          = 0",
+            "OK.",
+        ]
+        assert result == expected
+
+    def test_options_bad(self, tempsources):
+        result = runmain(
+            tempsources + "/*.rst",
+            "-o",
+            "module_relative=false, junk= 3, unknown=this",
+            expect_rc=1,
+        )
+        test_lines = [
+            f"ERROR occurred at PosixPath('{tempsources}/s0.rst'):"
+            " testfile() got an unexpected keyword argument 'junk'",
+            "    paths tested    = 0",
+            "    tests completed = 0",
+            "    errors          = 2",
+        ]
+        for line in test_lines:
+            assert line in result
+
+    def test_multi_exclude(self, tempsources):
+        result = runmain(
+            tempsources + "/**/*.rst",
+            "-d",
+            "-e",
+            "s1",
+            "-e",
+            "subdir2",
+        )
+        find_str = "doctest.testfile"
+        hits = [line for line in result if find_str in line]
+        name_prefix = find_str + f": {tempsources}/"
+        assert hits == [
+            name_prefix + name
+            for name in [
+                "s0.rst",
+                # "s1.rst",
+                # "subdir1/s1.rst",
+                "subdir1/s2.rst",
+                "subdir1/_px1.rst",
+                # "subdir2/s6.rst",
+                "subdir1/subsubdir1/s3.rst",
+                "subdir1/subsubdir1/s4.rst",
+                # "subdir1/subsubdir2/s4.rst",
+                # "subdir1/subsubdir2/s5.rst",
+                # "subdir1/subsubdir2/_px2.rst",
+            ]
+        ]
+
+
+class TestCliModules:
+    @pytest.mark.parametrize("publiconly", [False, True])
+    def test_modules_publiconly(self, publiconly):
+        """Check that the '-p' option is passed down."""
+        args = ["argparse", "-mdv"]  # NB list module: don't recurse or run actual tests
+        if publiconly:
+            args += ["-p"]
+        result = runmain(*args)
+        print("\n".join(result))
+        expect = f"include_private_modules={not publiconly}"
+        assert expect in result[0]
+
+    @pytest.mark.parametrize("recurse", [False, True])
+    def test_modules_recurse(self, recurse):
+        """Check that the '-r' option is passed down."""
+        # Test this with a stdlib module which has (just a few) submodules
+        args = ["json", "-mdv"]  # NB list modules, don't actually run tests
+        if recurse:
+            args += ["-r"]
+        result = runmain(*args)
+        print("\n".join(result))
+        expect = f"recurse_modules={recurse}"
+        assert expect in result[0]
+        n_mods = sum("doctest.testmod:" in line for line in result)
+        if recurse:
+            assert n_mods > 1
+        else:
+            assert n_mods == 1


### PR DESCRIPTION
Replaces #177 
Rebased to resolve conflicts, 
and, since we moved the repo into SciTools, also replace the branch with one in my fork (pp-mo/ncdata)

##TODO
Issues inherited from #177
  * [x]  [explain that 'private' does not apply to docs files](https://github.com/SciTools/ncdata/pull/177#discussion_r2472677638) 
  * [x] ~[find better way, or document, the odd way we are doing globs](https://github.com/SciTools/ncdata/pull/177#discussion_r2472688496)~ (update: it seems there just [isn't an easier way](https://stackoverflow.com/questions/51108256/how-to-take-a-pathname-string-with-wildcards-and-resolve-the-glob-with-pathlib))
  * [x] [tiny docs fix](https://github.com/SciTools/ncdata/pull/177#discussion_r2661223966)
  * [x] [explain limited translation of args for doctests function calls, avoiding exec](https://github.com/SciTools/ncdata/pull/177#discussion_r2661227138)
  * [x] [additional remaining](https://github.com/SciTools/ncdata/pull/177#issuecomment-3491528776)
    * [x] now complicated enough that it **needs some tests**
    * [x] ~possible problems with less usual glob forms (in include/target specs)~ (update: OK I think)
    * [x] ~support proper globs in exclude patterns ?~ (update: investigated, not very useful + too hard to explain)
    * [x] ~lack of global options config (? use a `pyproject.toml` section ?)~(update: investigated, too complicated to integrate with standard argparse, since defaults (especially bools) obscure what was actually commanded)

(and some more added since)
  * [x]  output reports currently say like e.g. 
          `1 item had failures:`
          `17 of  30 in lenient_metadata.rst`
          `***Test Failed*** 17 failures and 9 skipped tests.`
     * this should be clearer + especially include count of *successes*, so : "ok/bad/skip add up to total"
 * [x] ~ability to detect + skip internal sections that APPEAR like doctests, e.g. in ".. codeblock::"~
   (*dropped*: non-trival and would require deeper engagement with the doctests api, beyond 'testmod`/`testfile)

