### PR TITLE
Fix isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,8 +50,7 @@ repos:
     rev: 7.0.0
     hooks:
     -   id: isort
-        types: [file, python]
-        args: [--filter-files, --skip=./lib/ncdata/__init__.py]
+        name: isort (python)
 
 -   repo: https://github.com/asottile/blacken-docs
     rev: 1.20.0

--- a/lib/ncdata/utils/_compare_nc_datasets.py
+++ b/lib/ncdata/utils/_compare_nc_datasets.py
@@ -14,6 +14,7 @@ from warnings import warn
 import netCDF4
 import netCDF4 as nc
 import numpy as np
+
 from ncdata import NcData, NcVariable
 
 

--- a/lib/ncdata/utils/_dim_indexing.py
+++ b/lib/ncdata/utils/_dim_indexing.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping
 
 import dask.array as da
 import numpy as np
+
 from ncdata import NcData
 
 

--- a/lib/ncdata/utils/_save_errors.py
+++ b/lib/ncdata/utils/_save_errors.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 
 import netCDF4 as nc
 import numpy as np
+
 from ncdata import NcData, NcVariable
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ include = '\.pyi?$'
 [tool.isort]
 line_length = "79"
 profile = "black"
+known_local_folder = ["tests"]
+known_first_party = "ncdata"
+skip = ["lib/ncdata/__init__.py"]
 
 [tool.towncrier]
 package = "ncdata"

--- a/tests/integration/example_scripts/ex_dataset_print.py
+++ b/tests/integration/example_scripts/ex_dataset_print.py
@@ -1,6 +1,7 @@
 """Temporary integrational proof-of-concept example for dataset printout."""
 
 import iris
+
 import ncdata.iris as nci
 from ncdata import NcData, NcDimension, NcVariable
 

--- a/tests/integration/example_scripts/ex_iris_saveto_ncdata.py
+++ b/tests/integration/example_scripts/ex_iris_saveto_ncdata.py
@@ -5,6 +5,7 @@ Check that conversion succeeds and print the resulting dataset.
 """
 
 import iris
+
 from ncdata.iris import from_iris
 
 from tests import testdata_dir

--- a/tests/integration/example_scripts/ex_iris_xarray_conversion.py
+++ b/tests/integration/example_scripts/ex_iris_xarray_conversion.py
@@ -8,6 +8,7 @@ import dask.array as da
 import iris
 import numpy as np
 import xarray as xr
+
 from ncdata.iris_xarray import cubes_from_xarray, cubes_to_xarray
 
 from tests import testdata_dir

--- a/tests/integration/example_scripts/ex_ncdata_netcdf_conversion.py
+++ b/tests/integration/example_scripts/ex_ncdata_netcdf_conversion.py
@@ -10,6 +10,7 @@ from shutil import rmtree
 
 import netCDF4 as nc
 import numpy as np
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.netcdf4 import from_nc4, to_nc4
 from ncdata.utils import dataset_differences

--- a/tests/integration/test_iris_load_and_save_equivalence.py
+++ b/tests/integration/test_iris_load_and_save_equivalence.py
@@ -10,6 +10,7 @@ from subprocess import check_output
 
 import iris
 import pytest
+
 from ncdata.netcdf4 import from_nc4, to_nc4
 from ncdata.utils import dataset_differences
 

--- a/tests/integration/test_iris_xarray_roundtrips.py
+++ b/tests/integration/test_iris_xarray_roundtrips.py
@@ -14,6 +14,7 @@ import netCDF4
 import numpy as np
 import pytest
 import xarray
+
 from ncdata.iris import from_iris
 from ncdata.iris_xarray import cubes_to_xarray
 from ncdata.netcdf4 import from_nc4

--- a/tests/integration/test_xarray_load_and_save_equivalence.py
+++ b/tests/integration/test_xarray_load_and_save_equivalence.py
@@ -8,6 +8,7 @@ Testcases start as netcdf files.
 
 import pytest
 import xarray
+
 from ncdata.netcdf4 import from_nc4, to_nc4
 from ncdata.threadlock_sharing import lockshare_context
 from ncdata.utils import dataset_differences

--- a/tests/integration/test_zarr_to_iris.py
+++ b/tests/integration/test_zarr_to_iris.py
@@ -8,6 +8,7 @@ import iris
 import pytest
 import xarray as xr
 import zarr
+
 from ncdata.iris_xarray import cubes_from_xarray as conversion_func
 
 zarr_major_version = int(zarr.__version__.split(".")[0])

--- a/tests/unit/core/test_AttributeAccessMixin.py
+++ b/tests/unit/core/test_AttributeAccessMixin.py
@@ -7,6 +7,7 @@ All tests are run for both of those.
 
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcVariable
 
 

--- a/tests/unit/core/test_AttrvalsDict.py
+++ b/tests/unit/core/test_AttrvalsDict.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
+
 from ncdata import NcAttribute, NcVariable
 
 

--- a/tests/unit/core/test_NameMap.py
+++ b/tests/unit/core/test_NameMap.py
@@ -5,6 +5,7 @@ Tests for class :class:`ncdata.NameMap`.
 from copy import deepcopy
 
 import pytest
+
 from ncdata import NameMap, NcAttribute
 
 

--- a/tests/unit/core/test_NcAttribute.py
+++ b/tests/unit/core/test_NcAttribute.py
@@ -6,6 +6,7 @@ Very simple for now, but we may add more behaviour in future.
 
 import numpy as np
 import pytest
+
 from ncdata import NcAttribute
 
 # Support for building testcases

--- a/tests/unit/core/test_NcData.py
+++ b/tests/unit/core/test_NcData.py
@@ -4,6 +4,7 @@ There is almost no behaviour, but we can test some constructor usages.
 """
 
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 
 

--- a/tests/unit/core/test_NcDimension.py
+++ b/tests/unit/core/test_NcDimension.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from ncdata import NcDimension
 
 

--- a/tests/unit/core/test_NcVariable.py
+++ b/tests/unit/core/test_NcVariable.py
@@ -7,6 +7,7 @@ such as valid calling options and possibilities for data and dtype.
 import dask.array as da
 import numpy as np
 import pytest
+
 from ncdata import NcVariable
 from ncdata.utils import variable_differences
 

--- a/tests/unit/iris/test_from_iris.py
+++ b/tests/unit/iris/test_from_iris.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from iris.coords import DimCoord
 from iris.cube import Cube
+
 from ncdata.iris import from_iris
 
 from tests import MonitoredArray

--- a/tests/unit/iris/test_to_iris.py
+++ b/tests/unit/iris/test_to_iris.py
@@ -13,6 +13,7 @@ import dask.array as da
 import numpy as np
 from iris._constraints import NameConstraint
 from iris.cube import CubeList
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.iris import to_iris
 

--- a/tests/unit/netcdf/test_from_nc4.py
+++ b/tests/unit/netcdf/test_from_nc4.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import netCDF4 as nc
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.netcdf4 import from_nc4
 from ncdata.utils import dataset_differences

--- a/tests/unit/netcdf/test_to_nc4.py
+++ b/tests/unit/netcdf/test_to_nc4.py
@@ -15,6 +15,7 @@ from typing import List
 import netCDF4 as nc
 import numpy as np
 import pytest
+
 from ncdata import NcData
 from ncdata.netcdf4 import from_nc4, to_nc4
 from ncdata.utils import dataset_differences

--- a/tests/unit/utils/compare_nc_datasets/test_dataset_differences__additional.py
+++ b/tests/unit/utils/compare_nc_datasets/test_dataset_differences__additional.py
@@ -13,6 +13,7 @@ import warnings
 import netCDF4 as nc
 import numpy as np
 import pytest
+
 from ncdata.utils._compare_nc_datasets import (
     _attribute_differences,
     _namelist_differences,

--- a/tests/unit/utils/compare_nc_datasets/test_dataset_differences__mainfunctions.py
+++ b/tests/unit/utils/compare_nc_datasets/test_dataset_differences__mainfunctions.py
@@ -9,6 +9,7 @@ Split in two files ...
 
 import numpy as np
 import pytest
+
 from ncdata import NcAttribute, NcData, NcDimension, NcVariable
 from ncdata.utils import dataset_differences
 

--- a/tests/unit/utils/compare_nc_datasets/test_variable_differences.py
+++ b/tests/unit/utils/compare_nc_datasets/test_variable_differences.py
@@ -1,6 +1,7 @@
 import dask.array as da
 import numpy as np
 import pytest
+
 from ncdata import NcVariable
 from ncdata.utils import variable_differences
 

--- a/tests/unit/utils/dim_indexing/__init__.py
+++ b/tests/unit/utils/dim_indexing/__init__.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 
 

--- a/tests/unit/utils/dim_indexing/test_Slicer.py
+++ b/tests/unit/utils/dim_indexing/test_Slicer.py
@@ -5,6 +5,7 @@ This is the "indirect" approach, with a Slicer object.
 
 import numpy as np
 import pytest
+
 from ncdata.utils import Slicer, dataset_differences
 
 from . import (  # noqa: F401

--- a/tests/unit/utils/dim_indexing/test_index_by_dimensions.py
+++ b/tests/unit/utils/dim_indexing/test_index_by_dimensions.py
@@ -5,6 +5,7 @@ This is the more direct indexer approach.
 
 import numpy as np
 import pytest
+
 from ncdata.utils import dataset_differences, index_by_dimensions
 
 from . import (  # noqa: F401

--- a/tests/unit/utils/test_ncdata_copy.py
+++ b/tests/unit/utils/test_ncdata_copy.py
@@ -5,6 +5,7 @@ This is generic utility function version of the copy operation.
 
 import numpy as np
 import pytest
+
 from ncdata import NameMap, NcAttribute, NcData, NcDimension, NcVariable
 from ncdata.utils import dataset_differences, ncdata_copy
 

--- a/tests/unit/utils/test_rename_dimension.py
+++ b/tests/unit/utils/test_rename_dimension.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.utils import rename_dimension, save_errors
 

--- a/tests/unit/utils/test_save_errors.py
+++ b/tests/unit/utils/test_save_errors.py
@@ -6,6 +6,7 @@ import re
 
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.utils import save_errors
 

--- a/tests/unit/xarray/test_from_xarray.py
+++ b/tests/unit/xarray/test_from_xarray.py
@@ -15,6 +15,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
+
 from ncdata.xarray import from_xarray
 
 from tests import MonitoredArray

--- a/tests/unit/xarray/test_to_xarray.py
+++ b/tests/unit/xarray/test_to_xarray.py
@@ -12,6 +12,7 @@ covered by the generic 'roundtrip' testcases.
 import dask.array as da
 import numpy as np
 import pytest
+
 from ncdata import NcData, NcDimension, NcVariable
 from ncdata.xarray import to_xarray
 


### PR DESCRIPTION
Adopt + apply new isort settings.

Since we were getting repeated problems where the isort in CI on PRs disagreed with the local pre-commit fixes.
It seems this was due to confusion over what is a "firstparty" module, depdending (presumably) on the current directory when run.  Also similar problems recognising that "tests" is a local module.

Hopefully this resolves all that, and will **not** receive a pre-commit update on this PR.