### PR TITLE
linkcheck error fails the action.

### DIFF
--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -26,3 +26,8 @@ jobs:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
           labels: report, automated issue
+
+      - name: Fail Workflow On Link Errors
+        if: steps.lychee.outputs.exit_code != 0
+        run:
+          exit ${{ steps.lychee.outputs.exit_code }}

--- a/docs/changelog_fragments/192.dev.rst
+++ b/docs/changelog_fragments/192.dev.rst
@@ -1,0 +1,1 @@
+Moved repo to SciTools organisation.

--- a/docs/changelog_fragments/202.dev.rst
+++ b/docs/changelog_fragments/202.dev.rst
@@ -1,0 +1,1 @@
+When a linkcheck fails, return that errorcode from the Linkcheck action.


### PR DESCRIPTION
If a linkcheck errors, the action should also "fail".