### PR TITLE
Update RTD server image spec.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: mambaforge-4.10
   jobs:


### PR DESCRIPTION
In reponse to email from RTD, warning that ubuntu-20.04 is about to be retired.
Iris is now using "24.04"