### PR TITLE
Do not crash on arrays of strings

### DIFF
--- a/lib/ncdata/dataset_like.py
+++ b/lib/ncdata/dataset_like.py
@@ -281,21 +281,27 @@ class Nc4VariableLike(_Nc4DatalikeWithNcattrs):
                 add_offset = np.array(0, dtype=self.dtype)
         return is_scaled, scale_factor, add_offset
 
-    def _get_fillvalue(self):
+    def _get_fillvalue(self) -> int | float | None:
         """
         Calculate any applicable fill-value from attributes and netCDF4 defaults.
 
         Notes
         -----
         * this must be checked dynamically, as the attributes could change.
-        * for byte data, there is no netCDF default fill, so the result can be None.
+        * a default fill-value is not defined for all numpy dtypes, so the
+        * result can be None.
         """
         fv = self._ncdata.avals.get("_FillValue", None)
-        if fv is None:
-            if self.dtype.itemsize != 1:
-                # NOTE: single-byte types have NO default fill-value
-                dtype_code = self.dtype.str[1:]
-                fv = netCDF4.default_fillvals[dtype_code]
+        if fv is None and self.dtype.itemsize != 1:
+            # NOTE: from https://docs.unidata.ucar.edu/netcdf-c/4.9.2/attribute_conventions.html
+            # It is not necessary to define your own _FillValue attribute for a
+            # variable if the default fill value for the type of the variable
+            # is adequate. However, use of the default fill value for data type
+            # byte is not recommended.
+            # NOTE: xarray does not use default fill-values:
+            # https://github.com/pydata/xarray/issues/2742
+            dtype_code = self.dtype.str[1:]
+            fv = netCDF4.default_fillvals.get(dtype_code)
         return fv
 
     def _maskandscale_inner_to_apparent(self, array):


### PR DESCRIPTION
I'm trying to use `ncdata` to load Pangeo data into iris, but encountering issues with a dimension that contains string variables. Complete example code:

```python
import intake
import ncdata.iris_xarray

cat = intake.open_esm_datastore(
    "https://storage.googleapis.com/cmip6/pangeo-cmip6.json",
).search(
    table_id="Amon",
    source_id="GFDL-CM4",
    experiment_id="historical",
    variable_id="tas",
    member_id="r1i1p1f1",
)

ds = cat.to_dask()
# ds = ds.drop_vars(["member_id"])
print(ds)
cubes = ncdata.iris_xarray.cubes_from_xarray(ds)
print(cubes)
```

A similar issue was reported in #111. Here is a minimal reproducer:

```python
In [1]: import xarray as xr

In [2]: import ncdata.iris_xarray

In [3]: ds = xr.DataArray.from_dict({
   ...:     "coords": {
   ...:         "member_id": {"dims": "member_id", "data": ["r1i1p1f1"]}
   ...:     },
   ...:     "dims": "member_id",
   ...:     "data": [1],
   ...:     "name": "a",
   ...: }).to_dataset()
   ...: 

In [4]: ncdata.iris_xarray.cubes_from_xarray(ds)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[4], line 1
----> 1 ncdata.iris_xarray.cubes_from_xarray(ds)

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/iris_xarray.py:54, in cubes_from_xarray(xrds, xr_save_kwargs, iris_load_kwargs)
     52 xr_save_kwargs = xr_save_kwargs or {}
     53 ncdata = from_xarray(xrds, **xr_save_kwargs)
---> 54 cubes = to_iris(ncdata, **iris_load_kwargs)
     55 return cubes

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/iris.py:52, in to_iris(ncdata, **iris_load_kwargs)
     50     dslikes = [Nc4DatasetLike(data) for data in ncdata]
     51 else:
---> 52     dslikes = Nc4DatasetLike(ncdata)
     53 cubes = CubeList(iris.load(dslikes, **iris_load_kwargs))
     54 return cubes

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/dataset_like.py:112, in Nc4DatasetLike.__init__(self, ncdata)
    108 self._ncdata = ncdata
    109 # N.B. we need to create + store our OWN variables, as they are wrappers for
    110 #  the underlying NcVariable objects, with different properties.
    111 self.variables = {
--> 112     name: Nc4VariableLike._from_ncvariable(ncvar)
    113     for name, ncvar in self._ncdata.variables.items()
    114 }
    115 self.dimensions = {
    116     name: Nc4DimensionLike(dim) for name, dim in self._ncdata.dimensions.items()
    117 }

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/dataset_like.py:253, in Nc4VariableLike._from_ncvariable(cls, ncvar, dtype)
    251 if dtype is None:
    252     dtype = ncvar.dtype
--> 253 self = cls(
    254     ncvar=ncvar,
    255     datatype=dtype,
    256 )
    257 return self

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/dataset_like.py:246, in Nc4VariableLike.__init__(self, ncvar, datatype)
    240     array = da.ma.masked_array(da.zeros(self.shape, self.datatype), mask=True)
    242 # Convert from the "inner" raw form to masked-and-scaled, and then back again
    243 # (by assigning self._data_array).
    244 # This ensures that our inner data is stored with the correct fill-value, as
    245 # determined from our attributes and the netCDF4 default fill-values.
--> 246 array = self._maskandscale_inner_to_apparent(array)
    247 self._data_array = array

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/dataset_like.py:303, in Nc4VariableLike._maskandscale_inner_to_apparent(self, array)
    297 """
    298 Convert raw data values to masked+scaled.
    299 
    300 This replicates the netCDF4 default auto-scaling procedure.
    301 """
    302 # N.B. fill-value matches the internal raw (unscaled) values and dtype
--> 303 fv = self._get_fillvalue()
    304 if fv is not None:
    305     array = da.ma.masked_equal(array, fv)

File ~/mambaforge/envs/esmvaltool/lib/python3.13/site-packages/ncdata/dataset_like.py:293, in Nc4VariableLike._get_fillvalue(self)
    290     if self.dtype.itemsize != 1:
    291         # NOTE: single-byte types have NO default fill-value
    292         dtype_code = self.dtype.str[1:]
--> 293         fv = netCDF4.default_fillvals[dtype_code]
    294 return fv

KeyError: 'U8'
```

The code changes here result at least being able to load the cube, even if iris still not accepts string type DimCoords.

By the way, are you aware that xarray does not support using the default fill-value at all? https://github.com/pydata/xarray/issues/2742

@pp-mo Do you think this pull request could be a step in the right direction to making `ncdata` work with string arrays? I would be happy to continue working on this if you think it's worth it or close if you think a different approach is needed.